### PR TITLE
Removed TargetFormat.AppImage 

### DIFF
--- a/sample/composeApp/build.gradle.kts
+++ b/sample/composeApp/build.gradle.kts
@@ -190,7 +190,7 @@ compose.desktop {
         mainClass = "com.mifos.passcode.sample.MainKt"
 
         nativeDistributions {
-            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb, TargetFormat.Rpm, TargetFormat.AppImage, TargetFormat.Exe)
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb, TargetFormat.Rpm, TargetFormat.Exe)
             packageName = "com.mifos.passcode.sample"
             packageVersion = "1.0.0"
         }


### PR DESCRIPTION
Removed TargetFormat.AppImage from nativeDistributions for compose.desktop, as it was creating issues with building code on MacOS.