### PR TITLE
LocalCompositionProvider.kt is not providing the activity.

### DIFF
--- a/mifos-passcode-cmp/build.gradle.kts
+++ b/mifos-passcode-cmp/build.gradle.kts
@@ -19,22 +19,30 @@ kotlin {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
+            freeCompilerArgs.add("-Xexpect-actual-classes")
         }
     }
 
     js(IR) {
         browser()
         binaries.executable()
+        compilerOptions {
+            freeCompilerArgs.add("-Xexpect-actual-classes")
+        }
     }
 
     jvm("desktop") {
         compilations.all {
             kotlinOptions.jvmTarget = "1.8"
+            kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
         }
     }
 
     wasm {
         browser()
+        compilerOptions {
+            freeCompilerArgs.add("-Xexpect-actual-classes")
+        }
     }
 
     listOf(
@@ -45,6 +53,11 @@ kotlin {
         it.binaries.framework { 
             baseName = "mifos-passcode-cmp"
             isStatic = true
+        }
+        it.compilations.all {
+            kotlinOptions {
+                freeCompilerArgs +="-Xexpect-actual-classes"
+            }
         }
     }
     

--- a/mifos-passcode-cmp/src/androidMain/kotlin/AndroidAuthenticator.kt
+++ b/mifos-passcode-cmp/src/androidMain/kotlin/AndroidAuthenticator.kt
@@ -1,126 +1,123 @@
-import android.app.KeyguardManager
-import android.content.Context
-import android.content.Intent
-import android.os.Build
-import android.provider.Settings
-import androidx.annotation.RequiresApi
-import androidx.biometric.BiometricManager
-import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
-import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
-import androidx.biometric.BiometricPrompt
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.res.stringResource
-import androidx.fragment.app.FragmentActivity
-import com.mifos.passcode.auth.deviceAuth.domain.AuthenticationResult
-import com.mifos.passcode.auth.deviceAuth.domain.PlatformAuthenticator
-import com.mifos.passcode.biometric.domain.AuthenticatorStatus
-import io.github.openmf.mifos_passcode_cmp.generated.resources.Res
-import io.github.openmf.mifos_passcode_cmp.generated.resources.app_name
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlin.coroutines.resume
-
-
-class AndroidAuthenticator(
-    val activity: FragmentActivity,
-): PlatformAuthenticator {
-    private val bioMetricManager by lazy {
-        BiometricManager.from(activity)
-    }
-    private val authenticatorStatus by  mutableStateOf(AuthenticatorStatus())
-
-    override fun getDeviceAuthenticatorStatus(): AuthenticatorStatus {
-
-        val result = bioMetricManager.canAuthenticate(BIOMETRIC_STRONG)
-
-
-        val keyguardManager: KeyguardManager =
-            activity.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
-
-        authenticatorStatus.userCredentialSet = keyguardManager.isDeviceSecure
-
-        when(result){
-
-            BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE -> {
-                authenticatorStatus.message = "Hardware unavailable. Try again later."
-            }
-
-            BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED -> {
-                authenticatorStatus.message ="Biometrics not enrolled."
-                authenticatorStatus.biometricsNotPossible = false
-            }
-
-            BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE -> {
-                authenticatorStatus.message = "Biometrics not available."
-            }
-
-            BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED -> {
-                authenticatorStatus.message = "Vulnerabilities found. Security update required."
-            }
-
-            BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED -> {
-                authenticatorStatus.message = "Android version not supported."
-            }
-
-            BiometricManager.BIOMETRIC_STATUS_UNKNOWN -> {
-                authenticatorStatus.message = "Unable to determine whether the user can authenticate."
-            }
-
-            BiometricManager.BIOMETRIC_SUCCESS -> {
-                authenticatorStatus.biometricsSet = true
-                authenticatorStatus.biometricsNotPossible = false
-                authenticatorStatus.message = "Biometrics are set."
-            }
-        }
-
-        return authenticatorStatus
-
-    }
-
-    @RequiresApi(Build.VERSION_CODES.R)
-    override fun setDeviceAuthOption() {
-        val enrollBiometric = Intent(Settings.ACTION_BIOMETRIC_ENROLL).apply {
-            putExtra(
-                Settings.EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED,
-                BIOMETRIC_STRONG or DEVICE_CREDENTIAL
-            )
-        }
-        activity.startActivity(enrollBiometric)
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    override suspend fun authenticate(
-        title: String
-    ): AuthenticationResult = suspendCancellableCoroutine{ continuation ->
-
-        val promptInfo = BiometricPrompt.PromptInfo.Builder()
-            .setTitle(title)
-            .setSubtitle("Unlock using your PIN, Password, Pattern, Face or Fingerprint")
-            .setAllowedAuthenticators(BIOMETRIC_STRONG or DEVICE_CREDENTIAL)
-            .build()
-
-        val prompt = BiometricPrompt(
-            activity,
-            object: BiometricPrompt.AuthenticationCallback(){
-
-                override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
-                    super.onAuthenticationError(errorCode, errString)
-                    continuation.resume(AuthenticationResult.Error("${errorCode}: $errString"))
-                }
-
-                override fun onAuthenticationFailed() {
-                    super.onAuthenticationFailed()
-                    AuthenticationResult.Failed()
-                }
-
-                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
-                    super.onAuthenticationSucceeded(result)
-                    continuation.resume(AuthenticationResult.Success())
-                }
-            }
-        )
-
-        prompt.authenticate(promptInfo)
-    }
-}
+//import android.app.KeyguardManager
+//import android.content.Context
+//import android.content.Intent
+//import android.os.Build
+//import android.provider.Settings
+//import androidx.annotation.RequiresApi
+//import androidx.biometric.BiometricManager
+//import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
+//import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
+//import androidx.biometric.BiometricPrompt
+//import androidx.compose.runtime.getValue
+//import androidx.compose.runtime.mutableStateOf
+//import androidx.fragment.app.FragmentActivity
+//import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
+//import com.mifos.passcode.auth.deviceAuth.domain.AuthenticationResult
+//import com.mifos.passcode.biometric.domain.AuthenticatorStatus
+//import kotlinx.coroutines.ExperimentalCoroutinesApi
+//import kotlinx.coroutines.suspendCancellableCoroutine
+//import kotlin.coroutines.resume
+//
+//
+//class AndroidAuthenticator(
+//    val activity: FragmentActivity,
+//): PlatformAuthenticator {
+//    private val bioMetricManager by lazy {
+//        BiometricManager.from(activity)
+//    }
+//    private val authenticatorStatus by  mutableStateOf(AuthenticatorStatus())
+//
+//    override fun getDeviceAuthenticatorStatus(): AuthenticatorStatus {
+//
+//        val result = bioMetricManager.canAuthenticate(BIOMETRIC_STRONG)
+//
+//
+//        val keyguardManager: KeyguardManager =
+//            activity.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+//
+//        authenticatorStatus.userCredentialSet = keyguardManager.isDeviceSecure
+//
+//        when(result){
+//
+//            BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE -> {
+//                authenticatorStatus.message = "Hardware unavailable. Try again later."
+//            }
+//
+//            BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED -> {
+//                authenticatorStatus.message ="Biometrics not enrolled."
+//                authenticatorStatus.biometricsNotPossible = false
+//            }
+//
+//            BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE -> {
+//                authenticatorStatus.message = "Biometrics not available."
+//            }
+//
+//            BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED -> {
+//                authenticatorStatus.message = "Vulnerabilities found. Security update required."
+//            }
+//
+//            BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED -> {
+//                authenticatorStatus.message = "Android version not supported."
+//            }
+//
+//            BiometricManager.BIOMETRIC_STATUS_UNKNOWN -> {
+//                authenticatorStatus.message = "Unable to determine whether the user can authenticate."
+//            }
+//
+//            BiometricManager.BIOMETRIC_SUCCESS -> {
+//                authenticatorStatus.biometricsSet = true
+//                authenticatorStatus.biometricsNotPossible = false
+//                authenticatorStatus.message = "Biometrics are set."
+//            }
+//        }
+//
+//        return authenticatorStatus
+//
+//    }
+//
+//    @RequiresApi(Build.VERSION_CODES.R)
+//    override fun setDeviceAuthOption() {
+//        val enrollBiometric = Intent(Settings.ACTION_BIOMETRIC_ENROLL).apply {
+//            putExtra(
+//                Settings.EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED,
+//                BIOMETRIC_STRONG or DEVICE_CREDENTIAL
+//            )
+//        }
+//        activity.startActivity(enrollBiometric)
+//    }
+//
+//    @OptIn(ExperimentalCoroutinesApi::class)
+//    override suspend fun authenticate(
+//        title: String
+//    ): AuthenticationResult = suspendCancellableCoroutine{ continuation ->
+//
+//        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+//            .setTitle(title)
+//            .setSubtitle("Unlock using your PIN, Password, Pattern, Face or Fingerprint")
+//            .setAllowedAuthenticators(BIOMETRIC_STRONG or DEVICE_CREDENTIAL)
+//            .build()
+//
+//        val prompt = BiometricPrompt(
+//            activity,
+//            object: BiometricPrompt.AuthenticationCallback(){
+//
+//                override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+//                    super.onAuthenticationError(errorCode, errString)
+//                    continuation.resume(AuthenticationResult.Error("${errorCode}: $errString"))
+//                }
+//
+//                override fun onAuthenticationFailed() {
+//                    super.onAuthenticationFailed()
+//                    AuthenticationResult.Failed()
+//                }
+//
+//                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+//                    super.onAuthenticationSucceeded(result)
+//                    continuation.resume(AuthenticationResult.Success())
+//                }
+//            }
+//        )
+//
+//        prompt.authenticate(promptInfo)
+//    }
+//}

--- a/mifos-passcode-cmp/src/androidMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
+++ b/mifos-passcode-cmp/src/androidMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
@@ -36,6 +36,11 @@ actual class PlatformAuthenticator private actual constructor() {
 
         val result = bioMetricManager?.canAuthenticate(BIOMETRIC_STRONG) ?: 1
 
+        val keyguardManager: KeyguardManager =
+            applicationContext?.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+
+        authenticatorStatus.userCredentialSet = keyguardManager.isDeviceSecure
+
         when(result){
             BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE -> {
                 authenticatorStatus.message = "Hardware unavailable. Try again later."

--- a/mifos-passcode-cmp/src/commonMain/kotlin/LocalCompositionProvider.kt
+++ b/mifos-passcode-cmp/src/commonMain/kotlin/LocalCompositionProvider.kt
@@ -11,7 +11,7 @@ val LocalAndroidActivity = compositionLocalOf { Any() }
 
 @Composable
 fun LocalCompositionProvider(
-    activity: Any,
+    activity: Any = LocalAndroidActivity.current,
     platformAuthenticator: PlatformAuthenticator = PlatformAuthenticator(activity = activity),
     content: @Composable () -> Unit,
 ) {

--- a/mifos-passcode-cmp/src/commonMain/kotlin/LocalCompositionProvider.kt
+++ b/mifos-passcode-cmp/src/commonMain/kotlin/LocalCompositionProvider.kt
@@ -1,0 +1,31 @@
+package com.mifos.passcode
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
+import com.mifos.passcode.ui.viewmodels.DeviceAuthenticatorViewModel
+
+val LocalAndroidActivity = compositionLocalOf { Any() }
+
+@Composable
+fun LocalCompositionProvider(
+    activity: Any,
+    platformAuthenticator: PlatformAuthenticator = PlatformAuthenticator(activity = activity),
+    content: @Composable () -> Unit,
+) {
+    CompositionLocalProvider(
+        LocalAndroidActivity provides activity,
+        LocalPlatformAuthenticator provides platformAuthenticator,
+        content = content,
+    )
+}
+
+val LocalPlatformAuthenticator: ProvidableCompositionLocal<PlatformAuthenticator> = compositionLocalOf {
+    error("CompositionLocal PlatformAuthenticator not present")
+}
+
+val LocalDeviceAuthViewModel: ProvidableCompositionLocal<DeviceAuthenticatorViewModel> = compositionLocalOf {
+    error("CompositionLocal DeviceAuthenticatorViewModel not present")
+}

--- a/mifos-passcode-cmp/src/commonMain/kotlin/auth/demoImpl/DemoAuthenticator.kt
+++ b/mifos-passcode-cmp/src/commonMain/kotlin/auth/demoImpl/DemoAuthenticator.kt
@@ -1,25 +1,25 @@
 package com.mifos.passcode.auth.demoImpl
 
 import com.mifos.passcode.auth.deviceAuth.domain.AuthenticationResult
-import com.mifos.passcode.auth.deviceAuth.domain.PlatformAuthenticator
+import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import com.mifos.passcode.biometric.domain.AuthenticatorStatus
 
-class DemoAuthenticator: PlatformAuthenticator {
-
-    override fun getDeviceAuthenticatorStatus(): AuthenticatorStatus {
-        return AuthenticatorStatus(
-            userCredentialSet = false,
-            biometricsNotPossible = true,
-            biometricsSet = false,
-            message = "Coming Soon"
-        )
-    }
-
-    override fun setDeviceAuthOption() {}
-
-    override suspend fun authenticate(title: String): AuthenticationResult {
-        return AuthenticationResult.Error("Coming Soon")
-    }
-
-}
-
+//class DemoAuthenticator: PlatformAuthenticator {
+//
+//    override fun getDeviceAuthenticatorStatus(): AuthenticatorStatus {
+//        return AuthenticatorStatus(
+//            userCredentialSet = false,
+//            biometricsNotPossible = true,
+//            biometricsSet = false,
+//            message = "Coming Soon"
+//        )
+//    }
+//
+//    override fun setDeviceAuthOption() {}
+//
+//    override suspend fun authenticate(title: String): AuthenticationResult {
+//        return AuthenticationResult.Error("Coming Soon")
+//    }
+//
+//}
+//

--- a/mifos-passcode-cmp/src/commonMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
+++ b/mifos-passcode-cmp/src/commonMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
@@ -3,6 +3,7 @@ package com.mifos.passcode.auth.deviceAuth
 import com.mifos.passcode.auth.deviceAuth.domain.AuthenticationResult
 import com.mifos.passcode.biometric.domain.AuthenticatorStatus
 
+
 expect class PlatformAuthenticator private constructor(){
 
     constructor(activity: Any?)

--- a/mifos-passcode-cmp/src/commonMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
+++ b/mifos-passcode-cmp/src/commonMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
@@ -1,14 +1,15 @@
-package com.mifos.passcode.auth.deviceAuth.domain
+package com.mifos.passcode.auth.deviceAuth
 
+import com.mifos.passcode.auth.deviceAuth.domain.AuthenticationResult
 import com.mifos.passcode.biometric.domain.AuthenticatorStatus
 
+expect class PlatformAuthenticator private constructor(){
 
-interface PlatformAuthenticator {
-
+    constructor(activity: Any?)
     fun getDeviceAuthenticatorStatus(): AuthenticatorStatus
 
     fun setDeviceAuthOption()
 
     suspend fun authenticate(title: String = ""): AuthenticationResult
-}
 
+}

--- a/mifos-passcode-cmp/src/commonMain/kotlin/ui/screen/DeviceAuthScreen.kt
+++ b/mifos-passcode-cmp/src/commonMain/kotlin/ui/screen/DeviceAuthScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -17,7 +16,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mifos.passcode.LocalAndroidActivity
-import com.mifos.passcode.LocalPlatformAuthenticator
 import com.mifos.passcode.auth.AuthOption
 import com.mifos.passcode.auth.PlatformAuthOptions
 import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
@@ -29,9 +27,6 @@ import com.mifos.passcode.ui.components.SystemAuthenticatorButton
 import com.mifos.passcode.ui.viewmodels.DeviceAuthenticatorViewModel
 import io.github.openmf.mifos_passcode_cmp.generated.resources.Res
 import io.github.openmf.mifos_passcode_cmp.generated.resources.app_name
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.stateIn
 import org.jetbrains.compose.resources.stringResource
 
 
@@ -40,8 +35,9 @@ fun DeviceAuthScreen(
     authOption: AuthOption? = null,
     onDeviceAuthSuccess: () -> Unit = {},
 ) {
+    val platformAuthenticator = PlatformAuthenticator(LocalAndroidActivity.current)
 
-    val deviceAuthenticatorViewModel = DeviceAuthenticatorViewModel(LocalPlatformAuthenticator.current)
+    val deviceAuthenticatorViewModel = DeviceAuthenticatorViewModel(platformAuthenticator)
 
     val authenticationResult = deviceAuthenticatorViewModel.authenticationResult.collectAsStateWithLifecycle()
 

--- a/mifos-passcode-cmp/src/commonMain/kotlin/ui/screen/DeviceAuthScreen.kt
+++ b/mifos-passcode-cmp/src/commonMain/kotlin/ui/screen/DeviceAuthScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mifos.passcode.LocalAndroidActivity
+import com.mifos.passcode.LocalPlatformAuthenticator
 import com.mifos.passcode.auth.AuthOption
 import com.mifos.passcode.auth.PlatformAuthOptions
 import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
@@ -35,9 +36,8 @@ fun DeviceAuthScreen(
     authOption: AuthOption? = null,
     onDeviceAuthSuccess: () -> Unit = {},
 ) {
-    val platformAuthenticator = PlatformAuthenticator(LocalAndroidActivity.current)
 
-    val deviceAuthenticatorViewModel = DeviceAuthenticatorViewModel(platformAuthenticator)
+    val deviceAuthenticatorViewModel = DeviceAuthenticatorViewModel(LocalPlatformAuthenticator.current)
 
     val authenticationResult = deviceAuthenticatorViewModel.authenticationResult.collectAsStateWithLifecycle()
 

--- a/mifos-passcode-cmp/src/commonMain/kotlin/ui/screen/DeviceAuthScreen.kt
+++ b/mifos-passcode-cmp/src/commonMain/kotlin/ui/screen/DeviceAuthScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -15,8 +16,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mifos.passcode.LocalAndroidActivity
+import com.mifos.passcode.LocalPlatformAuthenticator
 import com.mifos.passcode.auth.AuthOption
 import com.mifos.passcode.auth.PlatformAuthOptions
+import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import com.mifos.passcode.auth.deviceAuth.domain.AuthenticationResult
 import com.mifos.passcode.getPlatform
 import com.mifos.passcode.ui.component.MifosIcon
@@ -25,6 +29,9 @@ import com.mifos.passcode.ui.components.SystemAuthenticatorButton
 import com.mifos.passcode.ui.viewmodels.DeviceAuthenticatorViewModel
 import io.github.openmf.mifos_passcode_cmp.generated.resources.Res
 import io.github.openmf.mifos_passcode_cmp.generated.resources.app_name
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.stateIn
 import org.jetbrains.compose.resources.stringResource
 
 
@@ -32,23 +39,22 @@ import org.jetbrains.compose.resources.stringResource
 fun DeviceAuthScreen(
     authOption: AuthOption? = null,
     onDeviceAuthSuccess: () -> Unit = {},
-    deviceAuthenticatorViewModel: DeviceAuthenticatorViewModel,
 ) {
 
+    val deviceAuthenticatorViewModel = DeviceAuthenticatorViewModel(LocalPlatformAuthenticator.current)
 
-    val authenticationResult =
-        deviceAuthenticatorViewModel.authenticationResult.collectAsStateWithLifecycle()
+    val authenticationResult = deviceAuthenticatorViewModel.authenticationResult.collectAsStateWithLifecycle()
 
-
-    val authenticatorStatus =
-        deviceAuthenticatorViewModel.authenticatorStatus.collectAsStateWithLifecycle()
+    val authenticatorStatus = deviceAuthenticatorViewModel.authenticatorStatus.collectAsStateWithLifecycle()
 
 
     var showAuthPrompt by rememberSaveable() {
         mutableStateOf(false)
     }
 
-    var showSetBiometricDialog by rememberSaveable(){ mutableStateOf(false) }
+    var showSetBiometricDialog by rememberSaveable{
+        mutableStateOf(false)
+    }
 
 
     if(authenticationResult.value == AuthenticationResult.Success() && showAuthPrompt){

--- a/mifos-passcode-cmp/src/commonMain/kotlin/ui/viewmodels/DeviceAuthenticatorViewModel.kt
+++ b/mifos-passcode-cmp/src/commonMain/kotlin/ui/viewmodels/DeviceAuthenticatorViewModel.kt
@@ -3,7 +3,7 @@ package com.mifos.passcode.ui.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mifos.passcode.auth.deviceAuth.domain.AuthenticationResult
-import com.mifos.passcode.auth.deviceAuth.domain.PlatformAuthenticator
+import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import com.mifos.passcode.biometric.domain.AuthenticatorStatus
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -91,7 +91,7 @@ class DeviceAuthenticatorViewModel(
 
     private fun getDeviceAuthenticatorStatus() = platformAuthenticator.getDeviceAuthenticatorStatus()
 
-    private suspend fun showDeviceAuthenticatorPrompt(title: String) {
+    suspend fun showDeviceAuthenticatorPrompt(title: String) {
         _authenticationResult.value = platformAuthenticator.authenticate(title)
     }
 

--- a/mifos-passcode-cmp/src/commonMain/kotlin/ui/viewmodels/DeviceAuthenticatorViewModel.kt
+++ b/mifos-passcode-cmp/src/commonMain/kotlin/ui/viewmodels/DeviceAuthenticatorViewModel.kt
@@ -6,8 +6,9 @@ import com.mifos.passcode.auth.deviceAuth.domain.AuthenticationResult
 import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import com.mifos.passcode.biometric.domain.AuthenticatorStatus
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 
@@ -80,17 +81,25 @@ class DeviceAuthenticatorViewModel(
     val platformAuthenticator: PlatformAuthenticator
 ): ViewModel(){
 
+
     private val _authenticationResult = MutableStateFlow<AuthenticationResult?>(null)
     val authenticationResult = _authenticationResult.asStateFlow()
 
     private val _authenticatorStatus = MutableStateFlow(AuthenticatorStatus())
-    val authenticatorStatus = _authenticatorStatus.asStateFlow()
+    val authenticatorStatus = _authenticatorStatus.stateIn(
+        viewModelScope,
+        started = SharingStarted.WhileSubscribed(1000),
+        initialValue = deviceAuthenticatorStatus()
+    )
 
     init {
-        _authenticatorStatus.value = getDeviceAuthenticatorStatus()
+        _authenticatorStatus.value = deviceAuthenticatorStatus()
     }
+    private fun deviceAuthenticatorStatus() = platformAuthenticator.getDeviceAuthenticatorStatus()
 
-    private fun getDeviceAuthenticatorStatus() = platformAuthenticator.getDeviceAuthenticatorStatus()
+    fun getDeviceAuthenticatorStatus(){
+        _authenticatorStatus.value = deviceAuthenticatorStatus()
+    }
 
     suspend fun showDeviceAuthenticatorPrompt(title: String) {
         _authenticationResult.value = platformAuthenticator.authenticate(title)

--- a/mifos-passcode-cmp/src/commonMain/kotlin/ui/viewmodels/DeviceAuthenticatorViewModel.kt
+++ b/mifos-passcode-cmp/src/commonMain/kotlin/ui/viewmodels/DeviceAuthenticatorViewModel.kt
@@ -7,6 +7,7 @@ import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import com.mifos.passcode.biometric.domain.AuthenticatorStatus
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 

--- a/mifos-passcode-cmp/src/desktopMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
+++ b/mifos-passcode-cmp/src/desktopMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
@@ -1,0 +1,23 @@
+package com.mifos.passcode.auth.deviceAuth
+
+import com.mifos.passcode.auth.deviceAuth.domain.AuthenticationResult
+import com.mifos.passcode.biometric.domain.AuthenticatorStatus
+
+actual class PlatformAuthenticator private actual constructor(){
+
+    actual constructor(activity: Any?) : this()
+    actual fun getDeviceAuthenticatorStatus(): AuthenticatorStatus {
+        return AuthenticatorStatus(
+            userCredentialSet = false,
+            biometricsNotPossible = true,
+            biometricsSet = false,
+            message = "Coming Soon"
+        )
+    }
+
+    actual fun setDeviceAuthOption() {}
+
+    actual suspend fun authenticate(title: String): AuthenticationResult {
+        return AuthenticationResult.Error("Coming Soon")
+    }
+}

--- a/mifos-passcode-cmp/src/iosMain/kotlin/auth/AuthOptions.desktop.kt
+++ b/mifos-passcode-cmp/src/iosMain/kotlin/auth/AuthOptions.desktop.kt
@@ -1,0 +1,2 @@
+package com.mifos.passcode.auth
+

--- a/mifos-passcode-cmp/src/iosMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
+++ b/mifos-passcode-cmp/src/iosMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
@@ -1,0 +1,23 @@
+package com.mifos.passcode.auth.deviceAuth
+
+import com.mifos.passcode.auth.deviceAuth.domain.AuthenticationResult
+import com.mifos.passcode.biometric.domain.AuthenticatorStatus
+
+actual class PlatformAuthenticator private actual constructor(){
+
+    actual constructor(activity: Any?) : this()
+    actual fun getDeviceAuthenticatorStatus(): AuthenticatorStatus {
+        return AuthenticatorStatus(
+            userCredentialSet = false,
+            biometricsNotPossible = true,
+            biometricsSet = false,
+            message = "Coming Soon"
+        )
+    }
+
+    actual fun setDeviceAuthOption() {}
+
+    actual suspend fun authenticate(title: String): AuthenticationResult {
+        return AuthenticationResult.Error("Coming Soon")
+    }
+}

--- a/mifos-passcode-cmp/src/jsMain/kotlin/auth/AuthOptions.desktop.kt
+++ b/mifos-passcode-cmp/src/jsMain/kotlin/auth/AuthOptions.desktop.kt
@@ -1,0 +1,2 @@
+package com.mifos.passcode.auth
+

--- a/mifos-passcode-cmp/src/jsMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
+++ b/mifos-passcode-cmp/src/jsMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
@@ -1,0 +1,23 @@
+package com.mifos.passcode.auth.deviceAuth
+
+import com.mifos.passcode.auth.deviceAuth.domain.AuthenticationResult
+import com.mifos.passcode.biometric.domain.AuthenticatorStatus
+
+actual class PlatformAuthenticator private actual constructor(){
+
+    actual constructor(activity: Any?) : this()
+    actual fun getDeviceAuthenticatorStatus(): AuthenticatorStatus {
+        return AuthenticatorStatus(
+            userCredentialSet = false,
+            biometricsNotPossible = true,
+            biometricsSet = false,
+            message = "Coming Soon"
+        )
+    }
+
+    actual fun setDeviceAuthOption() {}
+
+    actual suspend fun authenticate(title: String): AuthenticationResult {
+        return AuthenticationResult.Error("Coming Soon")
+    }
+}

--- a/mifos-passcode-cmp/src/wasmJsMain/kotlin/auth/AuthOptions.desktop.kt
+++ b/mifos-passcode-cmp/src/wasmJsMain/kotlin/auth/AuthOptions.desktop.kt
@@ -1,0 +1,2 @@
+package com.mifos.passcode.auth
+

--- a/mifos-passcode-cmp/src/wasmJsMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
+++ b/mifos-passcode-cmp/src/wasmJsMain/kotlin/auth/deviceAuth/PlatformAuthenticator.kt
@@ -1,0 +1,23 @@
+package com.mifos.passcode.auth.deviceAuth
+
+import com.mifos.passcode.auth.deviceAuth.domain.AuthenticationResult
+import com.mifos.passcode.biometric.domain.AuthenticatorStatus
+
+actual class PlatformAuthenticator private actual constructor(){
+
+    actual constructor(activity: Any?) : this()
+    actual fun getDeviceAuthenticatorStatus(): AuthenticatorStatus {
+        return AuthenticatorStatus(
+            userCredentialSet = false,
+            biometricsNotPossible = true,
+            biometricsSet = false,
+            message = "Coming Soon"
+        )
+    }
+
+    actual fun setDeviceAuthOption() {}
+
+    actual suspend fun authenticate(title: String): AuthenticationResult {
+        return AuthenticationResult.Error("Coming Soon")
+    }
+}

--- a/sample/composeApp/src/androidMain/kotlin/com/mifos/passcode/sample/MainActivity.kt
+++ b/sample/composeApp/src/androidMain/kotlin/com/mifos/passcode/sample/MainActivity.kt
@@ -4,15 +4,7 @@ import App
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.fragment.app.FragmentActivity
 import com.mifos.passcode.LocalCompositionProvider
-import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
-import com.mifos.passcode.ui.viewmodels.DeviceAuthenticatorViewModel
-import org.koin.core.context.loadKoinModules
-import org.koin.dsl.bind
-import org.koin.dsl.module
 
 
 class MainActivity : ComponentActivity() {

--- a/sample/composeApp/src/androidMain/kotlin/com/mifos/passcode/sample/MainActivity.kt
+++ b/sample/composeApp/src/androidMain/kotlin/com/mifos/passcode/sample/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.mifos.passcode.sample
 
-import AndroidAuthenticator
 import App
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -8,35 +7,40 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.fragment.app.FragmentActivity
-import com.mifos.passcode.auth.deviceAuth.domain.PlatformAuthenticator
+import com.mifos.passcode.LocalCompositionProvider
+import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
+import com.mifos.passcode.ui.viewmodels.DeviceAuthenticatorViewModel
 import org.koin.core.context.loadKoinModules
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 
-class MainActivity : FragmentActivity() {
+class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val androidAuthenticator = AndroidAuthenticator(this)
+//        val androidAuthenticator = AndroidAuthenticator(this)
+//
+//        // Dynamically create a module and register the initialized instance
+//        val activityModule = module {
+//            single { androidAuthenticator }.bind<PlatformAuthenticator>()
+//        }
+//
+//        // Load the module into Koin
+//        loadKoinModules(activityModule)
 
-        // Dynamically create a module and register the initialized instance
-        val activityModule = module {
-            single { androidAuthenticator }.bind<PlatformAuthenticator>()
-        }
-
-        // Load the module into Koin
-        loadKoinModules(activityModule)
 
         setContent {
-            App()
+            LocalCompositionProvider(this) {
+                App()
+            }
         }
     }
 }
 
 
-@Preview
-@Composable
-fun AppAndroidPreview() {
-    App()
-}
+//@Preview
+//@Composable
+//fun AppAndroidPreview() {
+//    App()
+//}

--- a/sample/composeApp/src/androidMain/kotlin/com/mifos/passcode/sample/MainActivity.kt
+++ b/sample/composeApp/src/androidMain/kotlin/com/mifos/passcode/sample/MainActivity.kt
@@ -4,10 +4,16 @@ import App
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.fragment.app.FragmentActivity
 import com.mifos.passcode.LocalCompositionProvider
 
+/*
+ * I am using FragmentActivity here because when MainActivity (when AppCompatActivity or ComponentActivity) is attempted to cast into FragmentActivity
+ * the app is crashing.
+ * Exception: java.lang.ClassCastException: com.mifos.passcode.sample.MainActivity cannot be cast to androidx.fragment.app.FragmentActivity
+ **/
 
-class MainActivity : ComponentActivity() {
+class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/sample/composeApp/src/androidMain/kotlin/com/mifos/passcode/sample/di/Module.android.kt
+++ b/sample/composeApp/src/androidMain/kotlin/com/mifos/passcode/sample/di/Module.android.kt
@@ -1,7 +1,7 @@
 package com.mifos.passcode.sample.di
 
-import com.mifos.passcode.auth.AuthOption
 import auth.AuthOptionAndroid
+import com.mifos.passcode.auth.AuthOption
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -9,6 +9,5 @@ import org.koin.dsl.module
 
 
 actual val platformModule: Module = module {
-
     singleOf(::AuthOptionAndroid).bind<AuthOption>()
 }

--- a/sample/composeApp/src/appleMain/kotlin/com/mifos/passcode/sample/di/Module.apple.kt
+++ b/sample/composeApp/src/appleMain/kotlin/com/mifos/passcode/sample/di/Module.apple.kt
@@ -1,4 +1,12 @@
 package com.mifos.passcode.sample.di
 
-actual val platformModule: org.koin.core.module.Module
-    get() = TODO("Not yet implemented")
+import com.mifos.passcode.auth.AuthOption
+import com.mifos.passcode.auth.demoImpl.DemoAuthOption
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+actual val platformModule: Module = module {
+    singleOf(::DemoAuthOption).bind<AuthOption>()
+}

--- a/sample/composeApp/src/commonMain/kotlin/com/mifos/passcode/sample/App.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/mifos/passcode/sample/App.kt
@@ -2,8 +2,6 @@
 
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import com.mifos.passcode.LocalAndroidActivity
-import com.mifos.passcode.LocalCompositionProvider
 import com.mifos.passcode.sample.navigation.PasscodeNavigation
 import org.jetbrains.compose.ui.tooling.preview.Preview
 

--- a/sample/composeApp/src/commonMain/kotlin/com/mifos/passcode/sample/App.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/mifos/passcode/sample/App.kt
@@ -2,6 +2,8 @@
 
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import com.mifos.passcode.LocalAndroidActivity
+import com.mifos.passcode.LocalCompositionProvider
 import com.mifos.passcode.sample.navigation.PasscodeNavigation
 import org.jetbrains.compose.ui.tooling.preview.Preview
 

--- a/sample/composeApp/src/commonMain/kotlin/com/mifos/passcode/sample/di/Module.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/mifos/passcode/sample/di/Module.kt
@@ -2,6 +2,7 @@ package com.mifos.passcode.sample.di
 
 import auth.preferenceDataStore.PreferenceDataStore
 import auth.preferenceDataStore.PreferenceDataStoreImpl
+import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import com.mifos.passcode.auth.deviceAuth.data.repository.ChooseAuthOptionRepository
 import com.mifos.passcode.auth.passcode.data.repository.PasscodeRepositoryImpl
 import com.mifos.passcode.auth.passcode.domain.PasscodeRepository
@@ -10,6 +11,7 @@ import com.mifos.passcode.ui.viewmodels.PasscodeViewModel
 import com.mifos.passcode.ui.viewmodels.DeviceAuthenticatorViewModel
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -23,6 +25,5 @@ val sharedModule = module {
     singleOf(constructor = ::PreferenceDataStoreImpl).bind<PreferenceDataStore>()
 
     viewModelOf(::PasscodeViewModel)
-    viewModelOf(::DeviceAuthenticatorViewModel)
     viewModelOf(::ChooseAuthOptionViewModel)
 }

--- a/sample/composeApp/src/commonMain/kotlin/com/mifos/passcode/sample/navigation/PasscodeScreenNavigation.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/mifos/passcode/sample/navigation/PasscodeScreenNavigation.kt
@@ -33,8 +33,7 @@ fun PasscodeNavigation(){
 
     val navController = rememberNavController()
     val passcodeViewModel: PasscodeViewModel = koinViewModel()
-    val deviceAuthenticatorViewModel: DeviceAuthenticatorViewModel = koinViewModel()
-    val  chooseAuthOptionViewModel: ChooseAuthOptionViewModel = koinViewModel()
+    val chooseAuthOptionViewModel: ChooseAuthOptionViewModel = koinViewModel()
 
     NavHost(
         navController = navController,
@@ -112,7 +111,6 @@ fun PasscodeNavigation(){
                         popUpTo(0)
                     }
                 },
-                deviceAuthenticatorViewModel = deviceAuthenticatorViewModel,
             )
         }
     }

--- a/sample/composeApp/src/desktopMain/kotlin/com/mifos/passcode/sample/di/Module.desktop.kt
+++ b/sample/composeApp/src/desktopMain/kotlin/com/mifos/passcode/sample/di/Module.desktop.kt
@@ -3,7 +3,7 @@ package com.mifos.passcode.sample.di
 import com.mifos.passcode.auth.AuthOption
 import com.mifos.passcode.auth.demoImpl.DemoAuthOption
 import com.mifos.passcode.auth.demoImpl.DemoAuthenticator
-import com.mifos.passcode.auth.deviceAuth.domain.PlatformAuthenticator
+import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind

--- a/sample/composeApp/src/desktopMain/kotlin/com/mifos/passcode/sample/di/Module.desktop.kt
+++ b/sample/composeApp/src/desktopMain/kotlin/com/mifos/passcode/sample/di/Module.desktop.kt
@@ -2,8 +2,6 @@ package com.mifos.passcode.sample.di
 
 import com.mifos.passcode.auth.AuthOption
 import com.mifos.passcode.auth.demoImpl.DemoAuthOption
-import com.mifos.passcode.auth.demoImpl.DemoAuthenticator
-import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -11,5 +9,4 @@ import org.koin.dsl.module
 
 actual val platformModule: Module = module {
     singleOf(::DemoAuthOption).bind<AuthOption>()
-    singleOf(::DemoAuthenticator).bind<PlatformAuthenticator>()
 }

--- a/sample/composeApp/src/iosMain/kotlin/com/mifos/passcode/sample/di/Module.ios.kt
+++ b/sample/composeApp/src/iosMain/kotlin/com/mifos/passcode/sample/di/Module.ios.kt
@@ -3,7 +3,7 @@ package com.mifos.passcode.sample.di
 import com.mifos.passcode.auth.AuthOption
 import com.mifos.passcode.auth.demoImpl.DemoAuthOption
 import com.mifos.passcode.auth.demoImpl.DemoAuthenticator
-import com.mifos.passcode.auth.deviceAuth.domain.PlatformAuthenticator
+import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind

--- a/sample/composeApp/src/iosMain/kotlin/com/mifos/passcode/sample/di/Module.ios.kt
+++ b/sample/composeApp/src/iosMain/kotlin/com/mifos/passcode/sample/di/Module.ios.kt
@@ -2,8 +2,6 @@ package com.mifos.passcode.sample.di
 
 import com.mifos.passcode.auth.AuthOption
 import com.mifos.passcode.auth.demoImpl.DemoAuthOption
-import com.mifos.passcode.auth.demoImpl.DemoAuthenticator
-import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -11,5 +9,4 @@ import org.koin.dsl.module
 
 actual val platformModule: Module = module {
     singleOf(::DemoAuthOption).bind<AuthOption>()
-    singleOf(::DemoAuthenticator).bind<PlatformAuthenticator>()
 }

--- a/sample/composeApp/src/nativeMain/kotlin/com/mifos/passcode/sample/di/Module.native.kt
+++ b/sample/composeApp/src/nativeMain/kotlin/com/mifos/passcode/sample/di/Module.native.kt
@@ -3,7 +3,7 @@ package com.mifos.passcode.sample.di
 import com.mifos.passcode.auth.AuthOption
 import com.mifos.passcode.auth.demoImpl.DemoAuthOption
 import com.mifos.passcode.auth.demoImpl.DemoAuthenticator
-import com.mifos.passcode.auth.deviceAuth.domain.PlatformAuthenticator
+import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind

--- a/sample/composeApp/src/nativeMain/kotlin/com/mifos/passcode/sample/di/Module.native.kt
+++ b/sample/composeApp/src/nativeMain/kotlin/com/mifos/passcode/sample/di/Module.native.kt
@@ -2,8 +2,6 @@ package com.mifos.passcode.sample.di
 
 import com.mifos.passcode.auth.AuthOption
 import com.mifos.passcode.auth.demoImpl.DemoAuthOption
-import com.mifos.passcode.auth.demoImpl.DemoAuthenticator
-import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -11,5 +9,4 @@ import org.koin.dsl.module
 
 actual val platformModule: Module = module {
     singleOf(::DemoAuthOption).bind<AuthOption>()
-    singleOf(::DemoAuthenticator).bind<PlatformAuthenticator>()
 }

--- a/sample/composeApp/src/wasmJsMain/kotlin/com/mifos/passcode/sample/di/Module.wasmJs.kt
+++ b/sample/composeApp/src/wasmJsMain/kotlin/com/mifos/passcode/sample/di/Module.wasmJs.kt
@@ -3,7 +3,7 @@ package com.mifos.passcode.sample.di
 import com.mifos.passcode.auth.AuthOption
 import com.mifos.passcode.auth.demoImpl.DemoAuthOption
 import com.mifos.passcode.auth.demoImpl.DemoAuthenticator
-import com.mifos.passcode.auth.deviceAuth.domain.PlatformAuthenticator
+import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind

--- a/sample/composeApp/src/wasmJsMain/kotlin/com/mifos/passcode/sample/di/Module.wasmJs.kt
+++ b/sample/composeApp/src/wasmJsMain/kotlin/com/mifos/passcode/sample/di/Module.wasmJs.kt
@@ -2,8 +2,6 @@ package com.mifos.passcode.sample.di
 
 import com.mifos.passcode.auth.AuthOption
 import com.mifos.passcode.auth.demoImpl.DemoAuthOption
-import com.mifos.passcode.auth.demoImpl.DemoAuthenticator
-import com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -11,5 +9,4 @@ import org.koin.dsl.module
 
 actual val platformModule: Module = module {
     singleOf(::DemoAuthOption).bind<AuthOption>()
-    singleOf(::DemoAuthenticator).bind<PlatformAuthenticator>()
 }


### PR DESCRIPTION
This currently will only compile for Android. I have switched to the expect/actual-based approach from the interface-based approach, and I have only written code for Android to see if things work. 
I am not handling the null values properly, maybe in the actual PlatformAuthenticator implementation of Android.
Or maybe I am now passing the activity properly.

---
## This is the error I am getting.

--------- beginning of crash
2025-05-02 22:42:06.573  4385-4385  AndroidRuntime          com.mifos.passcode.sample            E  FATAL EXCEPTION: main
                                                                                                    Process: com.mifos.passcode.sample, PID: 4385
                                                                                                    java.lang.NullPointerException: null cannot be cast to non-null type android.app.KeyguardManager
                                                                                                    	at com.mifos.passcode.auth.deviceAuth.PlatformAuthenticator.getDeviceAuthenticatorStatus(PlatformAuthenticator.kt:40)
                                                                                                    	at com.mifos.passcode.ui.viewmodels.DeviceAuthenticatorViewModel.getDeviceAuthenticatorStatus(DeviceAuthenticatorViewModel.kt:92)
                                                                                                    	at com.mifos.passcode.ui.viewmodels.DeviceAuthenticatorViewModel.<init>(DeviceAuthenticatorViewModel.kt:89)
                                                                                                    	at com.mifos.passcode.ui.screen.DeviceAuthScreenKt.DeviceAuthScreen(DeviceAuthScreen.kt:44)
                                                                                                    	at com.mifos.passcode.sample.navigation.PasscodeScreenNavigationKt$PasscodeNavigation$1$1$5.invoke(PasscodeScreenNavigation.kt:106)
                                                                                                    	at com.mifos.passcode.sample.navigation.PasscodeScreenNavigationKt$PasscodeNavigation$1$1$5.invoke(PasscodeScreenNavigation.kt:105)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:139)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
                                                                                                    	at androidx.navigation.compose.NavHostKt$NavHost$32$1.invoke(NavHost.kt:694)
                                                                                                    	at androidx.navigation.compose.NavHostKt$NavHost$32$1.invoke(NavHost.kt:693)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:109)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
                                                                                                    	at androidx.compose.runtime.CompositionLocalKt.CompositionLocalProvider(CompositionLocal.kt:401)
                                                                                                    	at androidx.compose.runtime.saveable.SaveableStateHolderImpl.SaveableStateProvider(SaveableStateHolder.kt:85)
                                                                                                    	at androidx.navigation.compose.NavBackStackEntryProviderKt.SaveableStateProvider(NavBackStackEntryProvider.kt:65)
                                                                                                    	at androidx.navigation.compose.NavBackStackEntryProviderKt.access$SaveableStateProvider(NavBackStackEntryProvider.kt:1)
                                                                                                    	at androidx.navigation.compose.NavBackStackEntryProviderKt$LocalOwnersProvider$1.invoke(NavBackStackEntryProvider.kt:52)
                                                                                                    	at androidx.navigation.compose.NavBackStackEntryProviderKt$LocalOwnersProvider$1.invoke(NavBackStackEntryProvider.kt:51)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:109)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
                                                                                                    	at androidx.compose.runtime.CompositionLocalKt.CompositionLocalProvider(CompositionLocal.kt:380)
                                                                                                    	at androidx.navigation.compose.NavBackStackEntryProviderKt.LocalOwnersProvider(NavBackStackEntryProvider.kt:47)
                                                                                                    	at androidx.navigation.compose.NavHostKt$NavHost$32.invoke(NavHost.kt:693)
                                                                                                    	at androidx.navigation.compose.NavHostKt$NavHost$32.invoke(NavHost.kt:674)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:139)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
                                                                                                    	at androidx.compose.animation.AnimatedContentKt$AnimatedContent$6$1$5.invoke(AnimatedContent.kt:803)
                                                                                                    	at androidx.compose.animation.AnimatedContentKt$AnimatedContent$6$1$5.invoke(AnimatedContent.kt:792)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:118)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
                                                                                                    	at androidx.compose.animation.AnimatedVisibilityKt.AnimatedEnterExitImpl(AnimatedVisibility.kt:771)
                                                                                                    	at androidx.compose.animation.AnimatedContentKt$AnimatedContent$6$1.invoke(AnimatedContent.kt:774)
                                                                                                    	at androidx.compose.animation.AnimatedContentKt$AnimatedContent$6$1.invoke(AnimatedContent.kt:757)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:109)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
                                                                                                    	at androidx.compose.animation.AnimatedContentKt.AnimatedContent(AnimatedContent.kt:816)
                                                                                                    	at androidx.navigation.compose.NavHostKt.NavHost(NavHost.kt:646)
                                                                                                    	at androidx.navigation.compose.NavHostKt$NavHost$34.invoke(Unknown Source:29)
2025-05-02 22:42:06.576  4385-4385  AndroidRuntime          com.mifos.passcode.sample            E  	at androidx.navigation.compose.NavHostKt$NavHost$34.invoke(Unknown Source:10)
                                                                                                    	at androidx.compose.runtime.RecomposeScopeImpl.compose(RecomposeScopeImpl.kt:192)
                                                                                                    	at androidx.compose.runtime.ComposerImpl.recomposeToGroupEnd(Composer.kt:2825)
                                                                                                    	at androidx.compose.runtime.ComposerImpl.skipCurrentGroup(Composer.kt:3116)
                                                                                                    	at androidx.compose.runtime.ComposerImpl.doCompose(Composer.kt:3607)
                                                                                                    	at androidx.compose.runtime.ComposerImpl.recompose$runtime_release(Composer.kt:3552)
                                                                                                    	at androidx.compose.runtime.CompositionImpl.recompose(Composition.kt:948)
                                                                                                    	at androidx.compose.runtime.Recomposer.performRecompose(Recomposer.kt:1206)
                                                                                                    	at androidx.compose.runtime.Recomposer.access$performRecompose(Recomposer.kt:132)
                                                                                                    	at androidx.compose.runtime.Recomposer$runRecomposeAndApplyChanges$2$1.invoke(Recomposer.kt:616)
                                                                                                    	at androidx.compose.runtime.Recomposer$runRecomposeAndApplyChanges$2$1.invoke(Recomposer.kt:585)
                                                                                                    	at androidx.compose.ui.platform.AndroidUiFrameClock$withFrameNanos$2$callback$1.doFrame(AndroidUiFrameClock.android.kt:41)
                                                                                                    	at androidx.compose.ui.platform.AndroidUiDispatcher.performFrameDispatch(AndroidUiDispatcher.android.kt:109)
                                                                                                    	at androidx.compose.ui.platform.AndroidUiDispatcher.access$performFrameDispatch(AndroidUiDispatcher.android.kt:41)
                                                                                                    	at androidx.compose.ui.platform.AndroidUiDispatcher$dispatchCallback$1.doFrame(AndroidUiDispatcher.android.kt:69)
                                                                                                    	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1568)
                                                                                                    	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1579)
                                                                                                    	at android.view.Choreographer.doCallbacks(Choreographer.java:1179)
                                                                                                    	at android.view.Choreographer.doFrame(Choreographer.java:1104)
                                                                                                    	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1553)
                                                                                                    	at android.os.Handler.handleCallback(Handler.java:995)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:103)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:248)
                                                                                                    	at android.os.Looper.loop(Looper.java:338)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:9067)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:932)
                                                                                                    	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [androidx.compose.runtime.PausableMonotonicFrameClock@193f096, androidx.compose.ui.platform.MotionDurationScaleImpl@94f5417, StandaloneCoroutine{Cancelling}@3300004, AndroidUiDispatcher@28969ed]
2025-05-02 22:42:06.612  4385-4385  Process                 com.mifos.passcode.sample            I  Sending signal. PID: 4385 SIG: 9
---------------------------- PROCESS ENDED (4385) for package com.mifos.passcode.sample ----------------------------
2025-05-02 22:42:06.651   743-872   InputDispatcher         system_server                        E  channel 'adfe8a1 com.mifos.passcode.sample/com.mifos.passcode.sample.MainActivity' ~ Channel is unrecoverably broken and will be disposed!

---
I know the code is written badly. I will clean everything as soon as I come back. I think the issue is with the LocalCompositionProvider not providing Activity from the LocalActivityProvider.current.



