### PR TITLE
Fix: Try again was showing only once even for multiple failed passcode attempts

### DIFF
--- a/mifos-passcode-cmp/src/commonMain/kotlin/auth/passcode/PasscodeSaver.kt
+++ b/mifos-passcode-cmp/src/commonMain/kotlin/auth/passcode/PasscodeSaver.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 /**
@@ -30,7 +31,8 @@ data class PasscodeState(
     val filledDots: Int = 0,
     val passcodeVisible: Boolean = false,
     val currentPasscodeInput: String = "",
-    val isPasscodeAlreadySet: Boolean = false
+    val isPasscodeAlreadySet: Boolean = false,
+    val attempts: Int = 0
 )
 
 /**
@@ -82,6 +84,8 @@ class PasscodeSaver(
     // State
     private val _state = MutableStateFlow(PasscodeState(isPasscodeAlreadySet = isPasscodeSet))
     val state: StateFlow<PasscodeState> = _state.asStateFlow()
+
+    var attempts = 0;
 
     // Internal data
     private var createPasscode = StringBuilder()
@@ -181,6 +185,12 @@ class PasscodeSaver(
                     createPasscode.clear()
                 } else {
                     emitEvent(PasscodeEvent.PasscodeRejected)
+                    attempts++
+                    _state.update {
+                        it.copy(
+                            attempts = this.attempts
+                        )
+                    }
                     // Logic for retries can be written here
                 }
                 updateState { copy(currentPasscodeInput = "") }

--- a/mifos-passcode-cmp/src/commonMain/kotlin/auth/passcode/screen/PasscodeScreen.kt
+++ b/mifos-passcode-cmp/src/commonMain/kotlin/auth/passcode/screen/PasscodeScreen.kt
@@ -47,7 +47,6 @@ import com.mifos.passcode.ui.component.PasscodeKeys
 import com.mifos.passcode.ui.theme.blueTint
 import com.mifos.passcode.utility.Constants.PASSCODE_LENGTH
 import com.mifos.passcode.utility.ShakeAnimation.performShakeAnimation
-import kotlinx.coroutines.delay
 
 
 /**
@@ -67,7 +66,7 @@ fun PasscodeScreen(
 
     val state by passcodeSaver.state.collectAsState()
 
-    val evets by passcodeSaver.events.collectAsState(
+    val events by passcodeSaver.events.collectAsState(
         initial = PasscodeEvent.NoPasscodeAction
     )
 
@@ -75,12 +74,15 @@ fun PasscodeScreen(
     var passcodeRejectedDialogVisible by remember { mutableStateOf(false) }
 
 
-    LaunchedEffect(evets){
-        when(evets){
+    LaunchedEffect(
+        key1= events,
+        key2= state.attempts
+    ){
+        when(events){
             is PasscodeEvent.NoPasscodeAction -> {}
             is PasscodeEvent.PasscodeConfirmed -> {
                 onPasscodeConfirm(
-                    (evets as PasscodeEvent.PasscodeConfirmed).passcode
+                    (events as PasscodeEvent.PasscodeConfirmed).passcode
                 )
             }
             is PasscodeEvent.PasscodeRejected -> {


### PR DESCRIPTION
After the recent changes to the library, the dialogue box when the pass-code fails was showing up only once and not for any other failed attempt after that.

|Before|After|
|:---:|:---:|
|<video src="https://github.com/user-attachments/assets/66ba470f-42d3-4b35-9c08-a8fc892cd26a" />|<video src="https://github.com/user-attachments/assets/b42f56e3-799d-439a-b394-199d28df98a2" />|

