### PR TITLE
Update publish workflow to support manual triggers and caching

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,15 @@ name: Publish
 on:
   release:
     types: [released, prereleased]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish'
+        required: true
+
+env:
+  PACKAGE_VERSION: ${{ github.event.inputs.version }}
+
 jobs:
   publish:
     name: Release build and publish
@@ -14,11 +23,47 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 21
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Cache gradle, wrapper and buildSrc
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Cache konan
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.konan/cache
+            ~/.konan/dependencies
+            ~/.konan/kotlin-native-macos*
+            ~/.konan/kotlin-native-mingw*
+            ~/.konan/kotlin-native-windows*
+            ~/.konan/kotlin-native-linux*
+            ~/.konan/kotlin-native-prebuilt-macos*
+            ~/.konan/kotlin-native-prebuilt-mingw*
+            ~/.konan/kotlin-native-prebuilt-windows*
+            ~/.konan/kotlin-native-prebuilt-linux*
+          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-konan-
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: 'latest-stable'
+
       - name: Publish to MavenCentral
-        run: ./gradlew publishToMavenCentral --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
+        run: ./gradlew publishToMavenCentral --no-configuration-cache


### PR DESCRIPTION
* Added `workflow_dispatch` trigger with a `version` input to allow manual publishing.
* Introduced `PACKAGE_VERSION` environment variable.
* Added caching for Gradle, wrapper, buildSrc, and Kotlin/Konan dependencies to improve build efficiency.
* Added Xcode setup step using `maxim-lobanov/setup-xcode`.
* Included `chmod +x gradlew` to ensure execute permissions for the Gradle wrapper.
* Passed `PACKAGE_VERSION` to the `publishToMavenCentral` task.