### PR TITLE
Version updates and workflow fixes

### DIFF
--- a/.github/workflows/publish_biometrics.yml
+++ b/.github/workflows/publish_biometrics.yml
@@ -1,0 +1,69 @@
+name: Publish
+on:
+  release:
+    types: [released, prereleased]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish'
+        required: true
+
+env:
+  BIOMETRICS_PACKAGE_VERSION: ${{ github.event.inputs.version }}
+
+jobs:
+  publish:
+    name: Release build and publish
+    runs-on: macOS-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Cache gradle, wrapper and buildSrc
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Cache konan
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.konan/cache
+            ~/.konan/dependencies
+            ~/.konan/kotlin-native-macos*
+            ~/.konan/kotlin-native-mingw*
+            ~/.konan/kotlin-native-windows*
+            ~/.konan/kotlin-native-linux*
+            ~/.konan/kotlin-native-prebuilt-macos*
+            ~/.konan/kotlin-native-prebuilt-mingw*
+            ~/.konan/kotlin-native-prebuilt-windows*
+            ~/.konan/kotlin-native-prebuilt-linux*
+          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-konan-
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: 'latest-stable'
+
+      - name: Publish to MavenCentral
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          BIOMETRICS_PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
+        run: ./gradlew publishToMavenCentral --no-configuration-cache

--- a/.github/workflows/publish_passcode.yml
+++ b/.github/workflows/publish_passcode.yml
@@ -9,7 +9,7 @@ on:
         required: true
 
 env:
-  PACKAGE_VERSION: ${{ github.event.inputs.version }}
+  PASSCODE_PACKAGE_VERSION: ${{ github.event.inputs.version }}
 
 jobs:
   publish:
@@ -65,5 +65,5 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-          PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
+          PASSCODE_PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
         run: ./gradlew publishToMavenCentral --no-configuration-cache

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,23 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google {
-            content {
-                includeGroupByRegex("com\\.android.*")
-                includeGroupByRegex("com\\.google.*")
-                includeGroupByRegex("androidx.*")
-            }
-        }
-        mavenCentral()
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath(libs.google.oss.licenses.plugin) {
-            exclude(group = "com.google.protobuf")
-        }
-    }
-}
-
 plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.androidTest) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,4 @@ android.useAndroidX=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 
 kotlin.native.ignoreDisabledTargets=true
+RingFile=/home/kalpesh/secring.gpg

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,3 @@ android.useAndroidX=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 
 kotlin.native.ignoreDisabledTargets=true
-RingFile=/home/kalpesh/secring.gpg

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,25 +1,25 @@
 [versions]
-agp = "8.12.3"
-componentsResources = "1.10.0"
-foundation = "1.10.0"
-htmlCore = "1.10.0"
-kotlin = "2.2.20"
+agp = "8.13.2"
+componentsResources = "1.10.1"
+foundation = "1.10.1"
+htmlCore = "1.10.1"
+kotlin = "2.3.0"
 android-minSdk = "26"
 android-compileSdk = "36"
 androidMavenGradlePlugin = "2.1"
-androidxActivity = "1.12.2"
+androidxActivity = "1.12.4"
 androidx-lifecycle = "2.10.0"
 material3 = "1.9.0"
 multiplatformSettings = "1.3.0"
 navigationComposeVersion = "2.9.1"
-compose-multiplatform = "1.10.0"
+compose-multiplatform = "1.10.1"
 kotlinxCoroutines = "1.10.2"
-kotlinSerialization = "1.9.0"
+kotlinSerialization = "1.10.0"
 koin = "4.1.1"
 biometricKtx = "1.1.0"
 material3Icons = "1.7.3"
 runtime = "1.10.0"
-uiToolingPreview = "1.10.0"
+uiToolingPreview = "1.10.1"
 webauthn4j = "0.29.2.RELEASE"
 kotlinStdlib = "2.3.0"
 runner = "1.7.0"
@@ -28,8 +28,8 @@ junit = "1.3.0"
 
 androidxComposeCompiler = "1.5.8"
 
-androidxComposeUi = "1.10.1"
-composeBom = "2026.01.01"
+androidxComposeUi = "1.10.3"
+composeBom = "2026.02.00"
 jna="5.18.1"
 jna-platform="3.5.2"
 kermit-logger = "2.0.8"
@@ -40,8 +40,8 @@ appcompat = "1.7.1"
 material = "1.13.0"
 
 
+vanniktech = "0.36.0"
 truth = "1.4.5"
-googleOssPlugin = "0.10.10"
 
 spotlessVersion = "8.2.1"
 detekt = "1.23.8"
@@ -49,12 +49,12 @@ twitter-detekt-compose = "0.0.26"
 ktlint = "14.0.1"
 dependencyGuard = "0.5.0"
 
-androidTools = "32.0.0"
+androidTools = "32.0.1"
 androidDesugarJdkLibs = "2.1.5"
 
-composeJB = "1.10.0"
+composeJB = "1.10.1"
 composeLifecycle = "2.9.6"
-composeNavigation = "2.9.1"
+composeNavigation = "2.9.2"
 jbCoreBundle = "1.0.1"
 jbSavedState = "1.4.0"
 
@@ -149,7 +149,6 @@ ktlint-gradlePlugin = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle"
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
 twitter-detekt-compose = { group = "com.twitter.compose.rules", name = "detekt", version.ref = "twitter-detekt-compose" }
 
-google-oss-licenses-plugin = { group = "com.google.android.gms", name = "oss-licenses-plugin", version.ref = "googleOssPlugin" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 
 
@@ -158,7 +157,7 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 androidTest = { id = "com.android.test", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.31.0" }
+vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 jetbrains-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -1068,7 +1068,7 @@ engine.io@~6.6.0:
     engine.io-parser "~5.2.1"
     ws "~8.17.1"
 
-enhanced-resolve@^5.17.2:
+enhanced-resolve@^5.17.3:
   version "5.19.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz#6687446a15e969eaa63c2fa2694510e17ae6d97c"
   integrity sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==
@@ -1773,10 +1773,9 @@ karma-webpack@5.0.1:
     minimatch "^9.0.3"
     webpack-merge "^4.1.5"
 
-karma@6.4.4:
+"karma@github:Kotlin/karma#6.4.5":
   version "6.4.4"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.4.tgz#dfa5a426cf5a8b53b43cd54ef0d0d09742351492"
-  integrity sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==
+  resolved "https://codeload.github.com/Kotlin/karma/tar.gz/239a8fc984584f0d96b1dd750e7a5e2c79da93a6"
   dependencies:
     "@colors/colors" "1.5.0"
     body-parser "^1.19.0"
@@ -1808,10 +1807,10 @@ kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-kotlin-web-helpers@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/kotlin-web-helpers/-/kotlin-web-helpers-2.1.0.tgz#6cd4b0f0dc3baea163929c8638155b8d19c55a74"
-  integrity sha512-NAJhiNB84tnvJ5EQx7iER3GWw7rsTZkX9HVHZpe7E3dDBD/dhTzqgSwNU3MfQjniy2rB04bP24WM9Z32ntUWRg==
+kotlin-web-helpers@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/kotlin-web-helpers/-/kotlin-web-helpers-3.0.0.tgz#3ed6b48f694f74bb60a737a9d7e2c0e3b29abdb9"
+  integrity sha512-kdQO4AJQkUPvpLh9aglkXDRyN+CfXO7pKq+GESEnxooBFkQpytLrqZis3ABvmFN1cGw/ZQ/K38u5sRGW+NfBnw==
   dependencies:
     format-util "^1.0.5"
 
@@ -1986,10 +1985,10 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
-mocha@11.7.1:
-  version "11.7.1"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.1.tgz#91948fecd624fb4bd154ed260b7e1ad3910d7c7a"
-  integrity sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==
+mocha@11.7.2:
+  version "11.7.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.2.tgz#3c0079fe5cc2f8ea86d99124debcc42bb1ab22b5"
+  integrity sha512-lkqVJPmqqG/w5jmmFtiRvtA2jkDyNVUcefFJKb2uyX4dekk8Okgqop3cgbFiaIvj8uCRJVTP5x9dfxGyXm2jvQ==
   dependencies:
     browser-stdout "^1.3.1"
     chokidar "^4.0.1"
@@ -2977,10 +2976,10 @@ webpack-sources@^3.3.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.3.3.tgz#d4bf7f9909675d7a070ff14d0ef2a4f3c982c723"
   integrity sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==
 
-webpack@5.100.2:
-  version "5.100.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.100.2.tgz#e2341facf9f7de1d702147c91bcb65b693adf9e8"
-  integrity sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==
+webpack@5.101.3:
+  version "5.101.3"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.101.3.tgz#3633b2375bb29ea4b06ffb1902734d977bc44346"
+  integrity sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==
   dependencies:
     "@types/eslint-scope" "^3.7.7"
     "@types/estree" "^1.0.8"
@@ -2992,7 +2991,7 @@ webpack@5.100.2:
     acorn-import-phases "^1.0.3"
     browserslist "^4.24.0"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.17.2"
+    enhanced-resolve "^5.17.3"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"

--- a/mifos-authenticator-biometrics/build.gradle.kts
+++ b/mifos-authenticator-biometrics/build.gradle.kts
@@ -7,8 +7,18 @@
  *
  * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
  */
+import com.vanniktech.maven.publish.DeploymentValidation
 
-import com.vanniktech.maven.publish.SonatypeHost
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
+ */
+
 
 plugins {
     alias(libs.plugins.vanniktech.mavenPublish)
@@ -17,7 +27,7 @@ plugins {
 
 
 android {
-    namespace = "com.mifos.authenticator.biometrics"
+    namespace = "io.github.openmf.mifos.authenticator.biometrics"
 }
 
 kotlin {
@@ -49,7 +59,7 @@ kotlin {
     }
 }
 
-val artifactId = "authenticator-biometrics"
+val artifactId = "mifos-authenticator-biometrics"
 val mavenGroup: String by project
 val defaultVersion: String by project
 val currentVersion = System.getenv("PACKAGE_VERSION") ?: defaultVersion
@@ -60,8 +70,7 @@ val githubRepo: String by project
 
 
 mavenPublishing {
-
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral(automaticRelease = true, validateDeployment = DeploymentValidation.PUBLISHED)
     signAllPublications()
     coordinates(mavenGroup, artifactId, currentVersion)
 
@@ -82,7 +91,7 @@ mavenPublishing {
         developers {
             developer {
                 id.set("openMF")
-                name.set("MIfos Initiative")
+                name.set("Mifos Initiative")
                 url.set("https://github.com/openMF")
             }
         }

--- a/mifos-authenticator-biometrics/gradle.properties
+++ b/mifos-authenticator-biometrics/gradle.properties
@@ -16,9 +16,9 @@ org.gradle.configureondemand=false
 # Enable caching between builds.
 org.gradle.caching=true
 
-mavenGroup=io.github.openMF
-defaultVersion=1.0.0
+mavenGroup=io.github.openmf
+defaultVersion=2.0.0
 desc=Kotlin Multiplatform library that provides a unified API for biometric authentication (e.g., fingerprint, face ID) and device credentials (e.g., PIN, password) across Android, iOS, Desktop and Web platforms. It simplifies the process of integrating platform-specific authentication mechanisms into your application, allowing you to write a single codebase for user authentication.
 license=MIT License
-creationYear=2025
+creationYear=2026
 githubRepo=openMF/mifos-passcode-cmp

--- a/mifos-authenticator-biometrics/src/desktopMain/kotlin/org/mifos/authenticator/biometrics/windows/utils/Helpers.kt
+++ b/mifos-authenticator-biometrics/src/desktopMain/kotlin/org/mifos/authenticator/biometrics/windows/utils/Helpers.kt
@@ -16,7 +16,7 @@ import java.io.InputStreamReader
 
 fun isWindowsTenOrEleven(): Boolean {
     val rt = Runtime.getRuntime()
-    val process = rt.exec("SYSTEMINFO")
+    val process = rt.exec(arrayOf("SYSTEMINFO"))
 
     val readOutput = BufferedReader(InputStreamReader(process.inputStream))
     var line: String?

--- a/mifos-authenticator-passcode/build.gradle.kts
+++ b/mifos-authenticator-passcode/build.gradle.kts
@@ -1,4 +1,13 @@
-import com.vanniktech.maven.publish.SonatypeHost
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
+ */
+import com.vanniktech.maven.publish.DeploymentValidation
 
 /*
  * Copyright 2026 Mifos Initiative
@@ -9,18 +18,19 @@ import com.vanniktech.maven.publish.SonatypeHost
  *
  * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
  */
+
 plugins {
     alias(libs.plugins.vanniktech.mavenPublish)
     alias(libs.plugins.mifos.cmp.feature)
 }
 
+
+android {
+    namespace = "io.github.openmf.mifos.authenticator.passcode"
+}
+
+
 kotlin {
-
-    android {
-        namespace = "org.mifos.authenticator.passcode"
-    }
-
-
     sourceSets {
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)
@@ -29,7 +39,7 @@ kotlin {
 
 }
 
-val artifactId = "authenticator-passcode"
+val artifactId = "mifos-authenticator-passcode"
 val mavenGroup: String by project
 val defaultVersion: String by project
 val currentVersion = System.getenv("PACKAGE_VERSION") ?: defaultVersion
@@ -40,7 +50,8 @@ val githubRepo: String by project
 
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    publishToMavenCentral(automaticRelease = true, validateDeployment = DeploymentValidation.PUBLISHED)
     signAllPublications()
     coordinates(mavenGroup, artifactId, currentVersion)
 
@@ -61,7 +72,7 @@ mavenPublishing {
         developers {
             developer {
                 id.set("openMF")
-                name.set("MIfos Initiative")
+                name.set("Mifos Initiative")
                 url.set("https://github.com/openMF")
             }
         }

--- a/mifos-authenticator-passcode/gradle.properties
+++ b/mifos-authenticator-passcode/gradle.properties
@@ -16,9 +16,9 @@ org.gradle.configureondemand=false
 # Enable caching between builds.
 org.gradle.caching=true
 
-mavenGroup=io.github.openMF
-defaultVersion=1.0.0
+mavenGroup=io.github.openmf
+defaultVersion=2.0.0
 desc=Kotlin Multiplatform passcode authentication library providing UI and logic for passcode creation, verification, and management across Android, iOS, Desktop, and Web using Compose Multiplatform.
 license=MIT License
-creationYear=2025
+creationYear=2026
 githubRepo=openMF/mifos-passcode-cmp


### PR DESCRIPTION
This pull request makes significant improvements to the publishing workflows, Gradle build configuration, and dependency versions for the biometrics and passcode modules. The main changes include splitting and enhancing the publishing workflows for biometrics and passcode, updating dependency versions, and standardizing project metadata and artifact naming.

**Workflow and Build Improvements:**

- Added dedicated GitHub Actions workflows for publishing the biometrics (`.github/workflows/publish_biometrics.yml`) and passcode (`.github/workflows/publish_passcode.yml`) modules, supporting both release and manual dispatch with version input, and removed the old monolithic publish workflow (`.github/workflows/publish.yml`). [[1]](diffhunk://#diff-7565ed482a9cc8646bc60959ff4e5e260dffba5f147f7d460f84577b4badb3dcR1-R69) [[2]](diffhunk://#diff-b8ed6465763187e60beb05ce317417fb4700182693586cecd191cdc00d1ded6aR1-R69) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L1-L24)
- Enhanced publishing configuration in `build.gradle.kts` for both modules to enable automatic release, deployment validation, and updated artifact IDs to include the `mifos-` prefix for clarity and consistency. [[1]](diffhunk://#diff-d74513d666e4b49afeb77ab5feda898af08aac8475e7f7b5d656566b6da1fdd0R1-R11) [[2]](diffhunk://#diff-d74513d666e4b49afeb77ab5feda898af08aac8475e7f7b5d656566b6da1fdd0L52-R62) [[3]](diffhunk://#diff-d74513d666e4b49afeb77ab5feda898af08aac8475e7f7b5d656566b6da1fdd0L63-R73) [[4]](diffhunk://#diff-5647101c5565ba16c7b9b0edf08617e25d43a354f4501683e90d88a708c9d159L1-R10) [[5]](diffhunk://#diff-5647101c5565ba16c7b9b0edf08617e25d43a354f4501683e90d88a708c9d159L32-R42) [[6]](diffhunk://#diff-5647101c5565ba16c7b9b0edf08617e25d43a354f4501683e90d88a708c9d159L43-R54)
- Updated the `namespace` in the biometrics and passcode modules to use the `io.github.openmf.mifos` package convention for better alignment with Maven Central and project standards. [[1]](diffhunk://#diff-d74513d666e4b49afeb77ab5feda898af08aac8475e7f7b5d656566b6da1fdd0L20-R30) [[2]](diffhunk://#diff-5647101c5565ba16c7b9b0edf08617e25d43a354f4501683e90d88a708c9d159R21-R33)

**Dependency and Plugin Updates:**

- Upgraded multiple dependency and plugin versions in `gradle/libs.versions.toml`, including Kotlin, Compose Multiplatform, Android Gradle Plugin, and others, to ensure compatibility and access to the latest features and fixes. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL2-R22) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL31-R32) [[3]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR43-R57)
- Changed the `vanniktech-mavenPublish` plugin versioning to use a version reference for easier maintenance, and removed the unused Google OSS licenses plugin. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL152) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL161-R160)

**Project Metadata and Legal Updates:**

- Updated project metadata in `gradle.properties` for both modules: changed the Maven group to lowercase (`io.github.openmf`), set the default version to `2.0.0`, and updated the creation year to 2026. [[1]](diffhunk://#diff-867c9875fb530b0ea4bb27ff9d498b145bbba7e1ccf499e08e16319bc7e8c36bL19-R23) [[2]](diffhunk://#diff-89d14f73e93594b34ce062b784587c626c559c4e44677249bdd484af1bc5c467L19-R23)
- Added or updated copyright and license headers in build scripts to ensure proper attribution and legal compliance. [[1]](diffhunk://#diff-d74513d666e4b49afeb77ab5feda898af08aac8475e7f7b5d656566b6da1fdd0R1-R11) [[2]](diffhunk://#diff-5647101c5565ba16c7b9b0edf08617e25d43a354f4501683e90d88a708c9d159L1-R10)

**Minor Fixes:**

- Fixed a minor process execution bug in the Windows helpers by changing the `exec` call to use an array argument for better compatibility.
- Corrected developer name capitalization in the Maven publishing configuration. [[1]](diffhunk://#diff-d74513d666e4b49afeb77ab5feda898af08aac8475e7f7b5d656566b6da1fdd0L85-R94) [[2]](diffhunk://#diff-5647101c5565ba16c7b9b0edf08617e25d43a354f4501683e90d88a708c9d159L64-R75)