### PR TITLE
Update GitHub workflow environment variables for publishing

### DIFF
--- a/.github/workflows/publish_biometrics.yml
+++ b/.github/workflows/publish_biometrics.yml
@@ -65,5 +65,5 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-          BIOMETRICS_PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
+          BIOMETRICS_PACKAGE_VERSION: ${{ env.BIOMETRICS_PACKAGE_VERSION }}
         run: ./gradlew publishToMavenCentral --no-configuration-cache

--- a/.github/workflows/publish_passcode.yml
+++ b/.github/workflows/publish_passcode.yml
@@ -65,5 +65,5 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-          PASSCODE_PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
+          PASSCODE_PACKAGE_VERSION: ${{ env.PASSCODE_PACKAGE_VERSION }}
         run: ./gradlew publishToMavenCentral --no-configuration-cache


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use more specific environment variables for package versioning in the biometrics and passcode publishing pipelines.

Workflow environment variable updates:

* In `.github/workflows/publish_biometrics.yml`, changed the environment variable from `PACKAGE_VERSION` to the more specific `BIOMETRICS_PACKAGE_VERSION` for the biometrics package publishing step.
* In `.github/workflows/publish_passcode.yml`, changed the environment variable from `PACKAGE_VERSION` to the more specific `PASSCODE_PACKAGE_VERSION` for the passcode package publishing step.