### PR TITLE
Bump version to 2.0.1 in authenticator modules

### DIFF
--- a/mifos-authenticator-biometrics/gradle.properties
+++ b/mifos-authenticator-biometrics/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.configureondemand=false
 org.gradle.caching=true
 
 mavenGroup=io.github.openmf
-defaultVersion=2.0.0
+defaultVersion=2.0.1
 desc=Kotlin Multiplatform library that provides a unified API for biometric authentication (e.g., fingerprint, face ID) and device credentials (e.g., PIN, password) across Android, iOS, Desktop and Web platforms. It simplifies the process of integrating platform-specific authentication mechanisms into your application, allowing you to write a single codebase for user authentication.
 license=MIT License
 creationYear=2026

--- a/mifos-authenticator-passcode/gradle.properties
+++ b/mifos-authenticator-passcode/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.configureondemand=false
 org.gradle.caching=true
 
 mavenGroup=io.github.openmf
-defaultVersion=2.0.0
+defaultVersion=2.0.1
 desc=Kotlin Multiplatform passcode authentication library providing UI and logic for passcode creation, verification, and management across Android, iOS, Desktop, and Web using Compose Multiplatform.
 license=MIT License
 creationYear=2026


### PR DESCRIPTION
Updated the `defaultVersion` to 2.0.1 in the `gradle.properties` files for both `mifos-authenticator-passcode` and `mifos-authenticator-biometrics` modules.