### PR TITLE
Removed skip passcode

### DIFF
--- a/.github/workflows/publish_biometrics.yml
+++ b/.github/workflows/publish_biometrics.yml
@@ -1,7 +1,5 @@
 name: Publish
 on:
-  release:
-    types: [released, prereleased]
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish_passcode.yml
+++ b/.github/workflows/publish_passcode.yml
@@ -1,7 +1,5 @@
 name: Publish
 on:
-  release:
-    types: [released, prereleased]
   workflow_dispatch:
     inputs:
       version:

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
@@ -50,13 +50,6 @@ fun SampleAppNavigation(
 
     val currentAppLock = chooseAuthOptionRepository.getAuthOption()
 
-//    val scope = rememberCoroutineScope()
-//
-//    val passcodeManager = rememberPasscodeManager(
-//        passcodeStorageAdapter,
-//        scope,
-//    )
-
     val isUsingPasscode = !passcodeStorageAdapter.loadPasscode().isNullOrBlank()
 
     val startDestination by remember {
@@ -108,12 +101,6 @@ fun SampleAppNavigation(
                 },
                 onForgotButton = {
                     navController.navigate(Route.LoginScreen) {
-                        popUpTo(0)
-                    }
-                },
-                onSkipButton = {
-                    navController.popBackStack()
-                    navController.navigate(Route.HomeScreen) {
                         popUpTo(0)
                     }
                 },

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/components/SystemAuthenticatorButton.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/components/SystemAuthenticatorButton.kt
@@ -13,20 +13,16 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -65,7 +61,7 @@ fun SystemAuthenticatorButton(
                                 platformAuthOptions.contains(PlatformAuthOptions.Fingerprint)
                             )
                     ) {
-                        ClickableTextButton(
+                        AuthenticateButton(
                             onClick = onClick,
                             text = "Use Biometrics",
                         )
@@ -133,7 +129,7 @@ fun SystemAuthenticatorButton(
                     authenticatorStatus.contains(PlatformAuthenticatorStatus.BIOMETRICS_SET) ||
                     authenticatorStatus.contains(PlatformAuthenticatorStatus.DEVICE_CREDENTIAL_SET)
                 ) {
-                    ClickableTextButton(
+                    AuthenticateButton(
                         onClick = onClick,
                         text = "Authenticate using Windows Hello",
                     )
@@ -152,34 +148,22 @@ fun SystemAuthenticatorButton(
 }
 
 @Composable
-fun ClickableTextButton(
-    onClick: () -> Unit,
-    enabled: Boolean = true,
+fun AuthenticateButton(
     text: String,
+    onClick: () -> Unit,
 ) {
-    TextButton(
+    Button(
         onClick = onClick,
-        enabled = enabled,
+        modifier = Modifier.height(50.dp)
+            .width(250.dp)
+            .clip(
+                RoundedCornerShape(30.dp),
+            )
+            .background(color = blueTint),
     ) {
-        Box(
-            modifier = Modifier.height(50.dp)
-                .width(250.dp)
-                .clip(
-                    RoundedCornerShape(30.dp),
-                )
-                .background(color = blueTint),
-            contentAlignment = Alignment.Center,
-        ) {
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Text(
-                    text,
-                    color = Color.White,
-                )
-            }
-        }
+        Text(
+            text,
+            color = Color.White,
+        )
     }
 }

--- a/mifos-authenticator-passcode/README.md
+++ b/mifos-authenticator-passcode/README.md
@@ -37,7 +37,9 @@ class MyPasscodeStorage : PasscodeStorageAdapter {
 
 ### 2. Initialize `PasscodeManager`
 
-In your navigation graph or parent Composable, create an instance of `PasscodeManager`. The library provides a `rememberPasscodeManager` helper function for this.
+#### Without dependency injection
+
+In your navigation graph or parent Composable, create an instance of `PasscodeManager` using the provided `rememberPasscodeManager` helper. It handles initialization automatically and ties the manager's lifecycle to the Composable.
 
 ```kotlin
 import androidx.compose.runtime.remember
@@ -52,6 +54,28 @@ val passcodeManager = rememberPasscodeManager(
     adapter = passcodeStorageAdapter,
     scope = scope
 )
+```
+
+#### With dependency injection (e.g. Koin)
+
+When `PasscodeManager` is registered as a **singleton**, it must be initialized exactly once — at creation time inside the DI module. Do **not** call `.initialize()` in composable injection sites (default parameters, `koinInject()` call sites, or `NavGraph` entries), as this will overwrite any step state set before navigation.
+
+```kotlin
+// DI module
+single { PasscodeManager(get(), MainScope()).initialize() }
+```
+
+```kotlin
+// NavGraph PasscodeScreen entry — inject without re-initializing
+val passcodeManager = koinInject<PasscodeManager>()
+```
+
+If you need the manager to start in `Create` mode (e.g. for first-time passcode setup), call `initialize()` explicitly on the **calling** screen before navigating, not inside the `PasscodeScreen` entry:
+
+```kotlin
+// ChooseAuthOptionScreen or equivalent first-time setup entry point
+passcodeManager.initialize()
+navController.navigate(Route.PasscodeScreen)
 ```
 
 ### 3. Setup Navigation
@@ -120,21 +144,34 @@ passcodeManager.trySendAction(PasscodeAction.ChangePasscode)
 navController.navigate(Route.PasscodeScreen)
 ```
 
-#### To Delete/Reset the Passcode (e.g., on Logout):
-Trigger the `DeletePasscode` action. This will clear the stored passcode via your adapter.
+#### To Delete the Passcode ("Forgot Passcode?" flow):
+
+Use `PasscodeAction.ForgetPasscode` from within `PasscodeScreen`. This deletes the stored passcode, resets the manager to `Create` mode, and emits `PasscodeEvent.OnPasscodeDeletion`, which `PasscodeScreen` collects to invoke `onForgotButton`. An active event collector is always present in this context.
 
 ```kotlin
-// On a "Logout" button click:
-passcodeManager.trySendAction(PasscodeAction.DeletePasscode)
-navController.navigate(Route.LoginScreen)
+// Wired automatically by PasscodeScreen's built-in "Forgot Passcode?" button.
+// If triggering manually from within PasscodeScreen:
+passcodeManager.trySendAction(PasscodeAction.ForgetPasscode)
 ```
+
+#### To Erase the Passcode on Logout (outside `PasscodeScreen`):
+
+Use `PasscodeAction.LogOutErasePasscode` from a logout button on a Home or Settings screen. This deletes the passcode directly via the adapter without emitting any event, so no stale event is buffered for the next session. Navigation is handled explicitly by your logout logic.
+
+```kotlin
+// On a "Logout" button click (outside PasscodeScreen):
+passcodeManager.trySendAction(PasscodeAction.LogOutErasePasscode)
+navController.navigate(Route.LoginScreen) { popUpTo(0) }
+```
+
+> **Why two separate actions?** `ForgetPasscode` emits `OnPasscodeDeletion` through an unbounded channel. If dispatched while `PasscodeScreen` is not in the back stack (no active collector), the event is buffered and immediately fires the next time the screen opens — sending the user to login before they can interact. `LogOutErasePasscode` avoids this by erasing storage silently with no event.
 
 ## Summary of Key Components
 
 *   **`PasscodeStorageAdapter`**: Interface you must implement for storage logic.
 *   **`PasscodeManager`**: State holder for the passcode logic.
 *   **`PasscodeScreen`**: The UI Composable provided by the library.
-*   **`PasscodeAction`**: Actions you can send to the manager (`ChangePasscode`, `DeletePasscode`).
+*   **`PasscodeAction`**: Actions you can send to the manager. Key actions: `ChangePasscode`, `ForgetPasscode` (from inside `PasscodeScreen`), `LogOutErasePasscode` (from outside `PasscodeScreen`).
 
 ## Customization
 

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
@@ -49,6 +49,11 @@ fun rememberPasscodeManager(
  * and the underlying storage ([PasscodeStorageAdapter]) for passcodes. It maintains the current
  * state of the passcode entry process in a [StateFlow].
  *
+ * The manager follows a unidirectional data flow (UDF) pattern:
+ * - **Actions**: UI sends [PasscodeAction]s to trigger logic.
+ * - **State**: UI collects [state] to reflect the current UI configuration.
+ * - **Events**: UI collects [events] for one-time side effects (e.g., navigation on success).
+ *
  * @param adapter The [PasscodeStorageAdapter] used for persisting and loading passcodes.
  * @param scope The [CoroutineScope] within which all internal coroutines (for handling actions and events) are launched.
  */
@@ -93,12 +98,18 @@ class PasscodeManager(
         }
     }
 
+    /** Temporary buffer for the passcode being created in the [PasscodeStep.Create] step. */
     private val creationPasscodeBuilder = StringBuilder()
+
+    /** Temporary buffer for the passcode being verified or confirmed in other steps. */
     private val finalConfirmationPasscodeBuilder = StringBuilder()
 
     /**
      * Initializes the [PasscodeManager] by loading any existing passcode and setting
      * the initial [PasscodeStep].
+     *
+     * If a passcode is already stored, it sets the step to [PasscodeStep.Enter].
+     * Otherwise, it sets the step to [PasscodeStep.Create].
      *
      * @return The initialized [PasscodeManager] instance.
      */
@@ -148,6 +159,9 @@ class PasscodeManager(
         }
     }
 
+    /**
+     * Updates the expected passcode length in the state.
+     */
     private fun updatePasscodeLength(length: PasscodeLength) {
         updateState {
             it.copy(
@@ -156,6 +170,9 @@ class PasscodeManager(
         }
     }
 
+    /**
+     * Deletes the last entered character from the active passcode builder.
+     */
     private fun deleteKey() {
         val passcodeBuilder = getActivePasscodeBuilder()
 
@@ -170,11 +187,18 @@ class PasscodeManager(
         }
     }
 
+    /**
+     * Clears all characters from the active passcode builder.
+     */
     private fun deleteAllKeys() {
         getActivePasscodeBuilder().clear()
         updateState { it.copy(currentPasscodeInput = "", filledDots = 0) }
     }
 
+    /**
+     * appends a character to the active passcode builder if the limit hasn't been reached.
+     * Triggers completion logic if the builder reaches the required length.
+     */
     private fun enterKey(key: String) {
         val currentState = _state.value
 
@@ -198,6 +222,9 @@ class PasscodeManager(
         }
     }
 
+    /**
+     * Toggles the visibility state of the passcode in the UI.
+     */
     private fun togglePasscodeVisibility() {
         updateState {
             it.copy(
@@ -206,12 +233,18 @@ class PasscodeManager(
         }
     }
 
+    /**
+     * Transitions the step to [PasscodeStep.ChangeVerify] to start the passcode change flow.
+     */
     private fun changePasscode() {
         updateState {
             it.copy(passcodeStep = PasscodeStep.ChangeVerify)
         }
     }
 
+    /**
+     * Dispatches the logic for handling a full passcode entry based on the current [PasscodeStep].
+     */
     private fun handleCompletedPasscodeEntry() {
         when (_state.value.passcodeStep) {
             PasscodeStep.ChangeVerify -> handleChangeVerifyPasscode()
@@ -222,6 +255,9 @@ class PasscodeManager(
         }
     }
 
+    /**
+     * Determines which [StringBuilder] to use based on the current flow step.
+     */
     private fun getActivePasscodeBuilder(): StringBuilder {
         return when (_state.value.passcodeStep) {
             PasscodeStep.ChangeVerify,
@@ -236,6 +272,10 @@ class PasscodeManager(
         }
     }
 
+    /**
+     * Validates the entered passcode against the stored one during the change flow.
+     * Transitions to [PasscodeStep.Create] on success, or emits [PasscodeEvent.OnRejectConfirmationPasscode] on failure.
+     */
     private fun handleChangeVerifyPasscode() {
         val loadedPasscode = adapter.loadPasscode()
         if (finalConfirmationPasscodeBuilder.toString() == loadedPasscode) {
@@ -254,6 +294,9 @@ class PasscodeManager(
         clearStates()
     }
 
+    /**
+     * Transitions from [PasscodeStep.Create] to [PasscodeStep.Confirm] after the first entry.
+     */
     private fun handleCreatePasscode() {
         updateState {
             it.copy(
@@ -265,6 +308,10 @@ class PasscodeManager(
         }
     }
 
+    /**
+     * Compares the confirmation entry with the initial creation entry.
+     * Saves the passcode on success, otherwise emits a rejection event.
+     */
     private fun handleConfirmPasscode() {
         val newPasscode = finalConfirmationPasscodeBuilder.toString()
         if (creationPasscodeBuilder.toString() == newPasscode) {
@@ -292,6 +339,9 @@ class PasscodeManager(
         finalConfirmationPasscodeBuilder.clear()
     }
 
+    /**
+     * Validates the entered passcode against the stored one to unlock.
+     */
     private fun handleEnterPasscode() {
         if (finalConfirmationPasscodeBuilder.toString() == _state.value.loadedPasscode) {
             emitEvent(PasscodeEvent.OnUnlockSuccess)
@@ -301,6 +351,9 @@ class PasscodeManager(
         clearStates()
     }
 
+    /**
+     * Resets the input-related state and clears the temporary builders.
+     */
     private fun clearStates() {
         updateState {
             it.copy(
@@ -317,6 +370,9 @@ class PasscodeManager(
         creationPasscodeBuilder.clear()
     }
 
+    /**
+     * Deletes the passcode from storage and resets the manager to the creation flow.
+     */
     private fun deletePasscode() {
         adapter.deletePasscode()
         updateState { it.copy(loadedPasscode = null, passcodeStep = PasscodeStep.Create) }
@@ -324,12 +380,18 @@ class PasscodeManager(
         emitEvent(PasscodeEvent.OnPasscodeDeletion)
     }
 
+    /**
+     * Utility to update the [_state] flow in a thread-safe manner.
+     */
     private fun updateState(update: (PasscodeState) -> PasscodeState) {
         _state.update {
             update(it)
         }
     }
 
+    /**
+     * Sends an event to the [_events] channel.
+     */
     private fun emitEvent(event: PasscodeEvent) = scope.launch {
         _events.send(event)
     }

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
@@ -399,8 +399,25 @@ sealed interface PasscodeEvent {
  * Represents actions that can be performed on the [PasscodeManager] to change its state or trigger logic.
  */
 sealed interface PasscodeAction {
-    /** Action to delete the stored passcode. */
+    /**
+     * Action for the "Forgot Passcode?" flow inside [PasscodeScreen].
+     *
+     * Deletes the stored passcode, resets the manager state to [PasscodeStep.Create],
+     * and emits [PasscodeEvent.OnPasscodeDeletion] so the screen can navigate away.
+     * **Only dispatch this action when [PasscodeScreen] is active** (i.e. when there is an active
+     * collector on [PasscodeManager.events]). Dispatching it while [PasscodeScreen] is not in the
+     * back stack will buffer the event; it will then fire immediately the next time the screen
+     * is opened, sending the user back to login before they can interact.
+     */
     object ForgetPasscode : PasscodeAction
+
+    /**
+     * Action to erase the stored passcode during a logout flow from outside [PasscodeScreen].
+     *
+     * Calls the [PasscodeStorageAdapter] to delete the passcode directly without emitting any
+     * event. Use this instead of [ForgetPasscode] whenever [PasscodeScreen] is not currently
+     * in the back stack (e.g. a logout button on a Home or Settings screen).
+     */
     object LogOutErasePasscode : PasscodeAction
 
     /** Action to initiate the passcode change flow. */

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/screen/PasscodeScreen.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/screen/PasscodeScreen.kt
@@ -54,7 +54,6 @@ import org.mifos.authenticator.passcode.components.PasscodeHeader
 import org.mifos.authenticator.passcode.components.PasscodeKeys
 import org.mifos.authenticator.passcode.components.PasscodeLengthSwitch
 import org.mifos.authenticator.passcode.components.PasscodeMismatchedDialog
-import org.mifos.authenticator.passcode.components.PasscodeSkipButton
 import org.mifos.authenticator.passcode.theme.changePasscodeLengthStyle
 import org.mifos.authenticator.passcode.theme.forgotButtonStyle
 import org.mifos.authenticator.passcode.theme.passcodeKeyButtonStyle
@@ -89,7 +88,6 @@ import org.mifos.authenticator.passcode.utility.ShakeAnimation.performShakeAnima
 fun PasscodeScreen(
     passcodeManager: PasscodeManager,
     onForgotButton: () -> Unit,
-    onSkipButton: () -> Unit,
     onPasscodeConfirm: () -> Unit,
     onPasscodeCreation: () -> Unit,
     onPasscodeRejected: () -> Unit,
@@ -100,7 +98,6 @@ fun PasscodeScreen(
     keyConfig: PasscodeKeyConfig = PasscodeKeyConfig(),
     buttonConfig: PasscodeButtonConfig = PasscodeButtonConfig(),
     switchConfig: PasscodeSwitchConfig = PasscodeSwitchConfig(),
-    toolbarConfig: PasscodeToolbarConfig = PasscodeToolbarConfig(),
     dialogConfig: PasscodeDialogConfig = PasscodeDialogConfig(),
 ) {
     // Provide composable defaults for nullable config properties
@@ -170,19 +167,6 @@ fun PasscodeScreen(
                 ),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-//            PasscodeToolbar(
-//                activeStep = state.activeStep,
-//                hasPasscode = state.isPasscodeAlreadySet,
-//                indicatorActiveColor = toolbarConfig.toolbarIndicatorActiveColor,
-//                indicatorInactiveColor = toolbarConfig.toolbarIndicatorInactiveColor,
-//            )
-
-            if (state.passcodeStep == PasscodeStep.Enter) {
-                PasscodeSkipButton(
-                    onSkipButton = onSkipButton,
-                    textStyle = effectiveButtonConfig.skipButtonTextStyle!!,
-                )
-            }
             Box(
                 modifier = Modifier.size(effectiveLogoConfig.logoSize),
                 contentAlignment = Alignment.Center,

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/screen/PasscodeScreenConfig.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/screen/PasscodeScreenConfig.kt
@@ -109,17 +109,6 @@ data class PasscodeSwitchConfig(
 )
 
 /**
- * Configuration for the optional toolbar indicators (e.g., for showing progress in passcode creation steps).
- *
- * @property toolbarIndicatorActiveColor The color of the active indicator in the toolbar.
- * @property toolbarIndicatorInactiveColor The color of the inactive indicators in the toolbar.
- */
-data class PasscodeToolbarConfig(
-    val toolbarIndicatorActiveColor: Color = blueTint,
-    val toolbarIndicatorInactiveColor: Color = Color.Gray,
-)
-
-/**
  * Configuration for the "Passcode Mismatched" dialog that appears on error.
  *
  * @property dialogContainerColor The background color of the dialog.


### PR DESCRIPTION
This pull request introduces several documentation improvements and codebase clarifications for the passcode manager and authentication flows. The main focus is on improving developer guidance for integrating the `PasscodeManager` (especially with dependency injection), clarifying passcode deletion flows, and enhancing code readability with detailed comments. Additionally, there are minor UI component refactors and workflow configuration cleanups.

**Documentation Improvements:**

* Expanded the README to clarify how to properly initialize and use `PasscodeManager` with and without dependency injection, including explicit instructions to avoid double-initialization and guidance for first-time setup flows. [[1]](diffhunk://#diff-5cdfdc5fd72c7afc5a2365cf2aa1db745849eff58c4d05f0986aeca7572a7534L40-R42) [[2]](diffhunk://#diff-5cdfdc5fd72c7afc5a2365cf2aa1db745849eff58c4d05f0986aeca7572a7534R59-R80)
* Added detailed explanations for the different passcode deletion actions (`ForgetPasscode` vs. `LogOutErasePasscode`) and when to use each, preventing event-buffering issues on logout.

**Codebase Documentation and Clarity:**

* Added or expanded KDoc comments throughout `PasscodeManager.kt` to explain the unidirectional data flow (UDF) pattern, internal state transitions, and the purpose of key methods and fields, improving maintainability and onboarding for new developers. [[1]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R52-R56) [[2]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R101-R113) [[3]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R162-R164) [[4]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R173-R175) [[5]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R190-R201) [[6]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R225-R227) [[7]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R236-R247) [[8]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R258-R260) [[9]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R275-R278) [[10]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R297-R299) [[11]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R311-R314) [[12]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R342-R344) [[13]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R354-R356) [[14]](diffhunk://#diff-bdebcc8ec7605fe4e4df52be2acc81f7391d0cbc9ad7de88711a190304311bb7R373-R394)

**UI Component Refactors:**

* Replaced the `ClickableTextButton` composable with a more appropriately styled `AuthenticateButton` (wrapping a Material3 `Button`) for biometric/system authentication actions, improving consistency and accessibility. [[1]](diffhunk://#diff-843cb406c410875c6ff1fc127385c5292b28db528382be2a418817038114712dL16-L29) [[2]](diffhunk://#diff-843cb406c410875c6ff1fc127385c5292b28db528382be2a418817038114712dL68-R64) [[3]](diffhunk://#diff-843cb406c410875c6ff1fc127385c5292b28db528382be2a418817038114712dL136-R132) [[4]](diffhunk://#diff-843cb406c410875c6ff1fc127385c5292b28db528382be2a418817038114712dL155-L185)

**Navigation and Logic Cleanups:**

* Removed unused coroutine scope and passcode manager instantiations, and eliminated the `onSkipButton` navigation logic in the sample app's navigation, simplifying the flow. [[1]](diffhunk://#diff-bf5d4868280bca20625157051ac77ffbf31febf79f146c4bb3f81d9bc7cb2560L53-L59) [[2]](diffhunk://#diff-bf5d4868280bca20625157051ac77ffbf31febf79f146c4bb3f81d9bc7cb2560L114-L119)

**Workflow Configuration:**

* Cleaned up GitHub Actions workflow triggers by removing the `release` event from the biometrics and passcode publish workflows, leaving only manual dispatch. [[1]](diffhunk://#diff-7565ed482a9cc8646bc60959ff4e5e260dffba5f147f7d460f84577b4badb3dcL3-L4) [[2]](diffhunk://#diff-b8ed6465763187e60beb05ce317417fb4700182693586cecd191cdc00d1ded6aL3-L4)