### PR TITLE
Handel cancellation of bio metric prompt by user && Critical bug fixes

### DIFF
--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
@@ -48,7 +48,6 @@ import org.mifos.authenticator.biometrics.platformAuthenticator.PlatformAuthenti
 import org.mifos.authenticator.biometrics.platformAuthenticator.RegistrationResult
 import org.mifos.authenticator.biometrics.platformAvailableAuthenticationOption
 import org.mifos.authenticator.passcode.PasscodeAction
-import org.mifos.authenticator.passcode.PasscodeAction.*
 import org.mifos.authenticator.passcode.PasscodeManager
 import org.mifos.authenticator.passcode.PasscodeStorageAdapter
 import org.mifos.authenticator.passcode.components.PasscodeKey

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
@@ -48,6 +48,7 @@ import org.mifos.authenticator.biometrics.platformAuthenticator.PlatformAuthenti
 import org.mifos.authenticator.biometrics.platformAuthenticator.RegistrationResult
 import org.mifos.authenticator.biometrics.platformAvailableAuthenticationOption
 import org.mifos.authenticator.passcode.PasscodeAction
+import org.mifos.authenticator.passcode.PasscodeAction.*
 import org.mifos.authenticator.passcode.PasscodeManager
 import org.mifos.authenticator.passcode.PasscodeStorageAdapter
 import org.mifos.authenticator.passcode.components.PasscodeKey
@@ -226,11 +227,13 @@ fun BiometricKey(
                             passcodeManager.trySendAction(PasscodeAction.BiometricUnlockSuccess)
                         }
                         is AuthenticationResult.Error -> {
-                            passcodeManager.trySendAction(PasscodeAction.BiometricUnlockFailure(result.message))
+                            passcodeManager.trySendAction(BiometricUnlockFailure(result.message))
                         }
                         is AuthenticationResult.UserNotRegistered -> {
                             onUserNotRegistered()
                         }
+
+                        AuthenticationResult.UserCancelled -> { /* User dismissed prompt, do nothing */ }
                     }
                 }
             },
@@ -345,6 +348,7 @@ fun HomeScreen(
                                 is RegistrationResult.Error -> {
                                     onBiometricsEnableError(result.message)
                                 }
+                                RegistrationResult.UserCancelled -> { /* User dismissed prompt, do nothing */ }
                             }
                         }
                     }

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
@@ -226,7 +226,11 @@ fun BiometricKey(
                             passcodeManager.trySendAction(PasscodeAction.BiometricUnlockSuccess)
                         }
                         is AuthenticationResult.Error -> {
-                            passcodeManager.trySendAction(BiometricUnlockFailure(result.message))
+                            passcodeManager.trySendAction(
+                                PasscodeAction.BiometricUnlockFailure(
+                                    result.message,
+                                ),
+                            )
                         }
                         is AuthenticationResult.UserNotRegistered -> {
                             onUserNotRegistered()

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/BiometricSetupScreen.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/BiometricSetupScreen.kt
@@ -115,6 +115,7 @@ fun BiometricSetupScreen(
                             is RegistrationResult.Error -> {
                                 onError(result.message)
                             }
+                            RegistrationResult.UserCancelled -> { /* User dismissed prompt, do nothing */ }
                         }
                     }
                 },

--- a/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
+++ b/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
@@ -88,7 +88,7 @@ actual class PlatformAuthenticator private actual constructor() {
             }
         }
 
-        println(authenticatorStatus)
+        Logger.d { "authenticatorStatus=$authenticatorStatus" }
         return authenticatorStatus
     }
 

--- a/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
+++ b/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
@@ -133,7 +133,7 @@ actual class PlatformAuthenticator private actual constructor() {
                                 BiometricPrompt.ERROR_USER_CANCELED,
                                 BiometricPrompt.ERROR_NEGATIVE_BUTTON,
                                 -> {
-                                    AuthenticationResult.Error("$errorCode: $errString")
+                                    AuthenticationResult.UserCancelled
                                 }
                                 else -> {
                                     AuthenticationResult.Error("$errorCode: $errString")

--- a/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
+++ b/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
@@ -128,12 +128,17 @@ actual class PlatformAuthenticator private actual constructor() {
                     override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
                         super.onAuthenticationError(errorCode, errString)
                         continuation.resume(
-                            when(errorCode) {
+                            when (errorCode) {
                                 BiometricPrompt.ERROR_CANCELED,
                                 BiometricPrompt.ERROR_USER_CANCELED,
-                                BiometricPrompt.ERROR_NEGATIVE_BUTTON -> {AuthenticationResult.Error("$errorCode: $errString")}
-                                else -> {AuthenticationResult.Error("$errorCode: $errString")}
-                            }
+                                BiometricPrompt.ERROR_NEGATIVE_BUTTON,
+                                -> {
+                                    AuthenticationResult.Error("$errorCode: $errString")
+                                }
+                                else -> {
+                                    AuthenticationResult.Error("$errorCode: $errString")
+                                }
+                            },
                         )
                     }
 

--- a/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
+++ b/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
@@ -132,7 +132,7 @@ actual class PlatformAuthenticator private actual constructor() {
 
                     override fun onAuthenticationFailed() {
                         super.onAuthenticationFailed()
-                        AuthenticationResult.Error(message = "Authentication Failed.")
+                        Logger.w { "Biometric authentication attempt failed, prompt remains open for retry" }
                     }
 
                     override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {

--- a/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
+++ b/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
@@ -127,7 +127,14 @@ actual class PlatformAuthenticator private actual constructor() {
 
                     override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
                         super.onAuthenticationError(errorCode, errString)
-                        continuation.resume(AuthenticationResult.Error("$errorCode: $errString"))
+                        continuation.resume(
+                            when(errorCode) {
+                                BiometricPrompt.ERROR_CANCELED,
+                                BiometricPrompt.ERROR_USER_CANCELED,
+                                BiometricPrompt.ERROR_NEGATIVE_BUTTON -> {AuthenticationResult.Error("$errorCode: $errString")}
+                                else -> {AuthenticationResult.Error("$errorCode: $errString")}
+                            }
+                        )
                     }
 
                     override fun onAuthenticationFailed() {
@@ -169,6 +176,9 @@ actual class PlatformAuthenticator private actual constructor() {
             }
             is AuthenticationResult.UserNotRegistered -> {
                 RegistrationResult.PlatformAuthenticatorNotSet
+            }
+            is AuthenticationResult.UserCancelled -> {
+                RegistrationResult.UserCancelled
             }
         }
     }

--- a/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAvailableAuthenticationOption.kt
+++ b/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAvailableAuthenticationOption.kt
@@ -48,9 +48,9 @@ actual class PlatformAvailableAuthenticationOption private actual constructor() 
             if (fingerprint) availablePlatformAuthOptions.add(PlatformAuthOptions.Fingerprint)
             if (iris) availablePlatformAuthOptions.add(PlatformAuthOptions.Iris)
 
-            Logger.d { "Does the device have fingerprint lock? $fingerprint"}
-            Logger.d { "Does the device have face lock? $face"}
-            Logger.d { "Does the device have iris lock? $iris"}
+            Logger.d { "Does the device have fingerprint lock? $fingerprint" }
+            Logger.d { "Does the device have face lock? $face" }
+            Logger.d { "Does the device have iris lock? $iris" }
         }
 
         return availablePlatformAuthOptions

--- a/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAvailableAuthenticationOption.kt
+++ b/mifos-authenticator-biometrics/src/androidMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAvailableAuthenticationOption.kt
@@ -14,6 +14,7 @@ package org.mifos.authenticator.biometrics.platformAuthenticator
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -47,9 +48,9 @@ actual class PlatformAvailableAuthenticationOption private actual constructor() 
             if (fingerprint) availablePlatformAuthOptions.add(PlatformAuthOptions.Fingerprint)
             if (iris) availablePlatformAuthOptions.add(PlatformAuthOptions.Iris)
 
-            println("Does the device have fingerprint lock? $fingerprint")
-            println("Does the device have face lock? $face")
-            println("Does the device have iris lock? $iris")
+            Logger.d { "Does the device have fingerprint lock? $fingerprint"}
+            Logger.d { "Does the device have face lock? $face"}
+            Logger.d { "Does the device have iris lock? $iris"}
         }
 
         return availablePlatformAuthOptions

--- a/mifos-authenticator-biometrics/src/commonMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/AuthenticationResult.kt
+++ b/mifos-authenticator-biometrics/src/commonMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/AuthenticationResult.kt
@@ -29,6 +29,11 @@ sealed interface AuthenticationResult {
     data class Error(val message: String) : AuthenticationResult
 
     /**
+     * Indicates that user cancelled the authentication request.
+     */
+    data object UserCancelled : AuthenticationResult
+
+    /**
      * Indicates that the authentication failed because the user is not registered.
      */
     data object UserNotRegistered : AuthenticationResult

--- a/mifos-authenticator-biometrics/src/commonMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/RegistrationResult.kt
+++ b/mifos-authenticator-biometrics/src/commonMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/RegistrationResult.kt
@@ -31,6 +31,7 @@ sealed interface RegistrationResult {
      */
     data class Error(val message: String) : RegistrationResult
 
+    data object UserCancelled: RegistrationResult
     /**
      * Indicates that the registration failed because the platform authenticator is not set up.
      */

--- a/mifos-authenticator-biometrics/src/commonMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/RegistrationResult.kt
+++ b/mifos-authenticator-biometrics/src/commonMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/RegistrationResult.kt
@@ -31,7 +31,8 @@ sealed interface RegistrationResult {
      */
     data class Error(val message: String) : RegistrationResult
 
-    data object UserCancelled: RegistrationResult
+    data object UserCancelled : RegistrationResult
+
     /**
      * Indicates that the registration failed because the platform authenticator is not set up.
      */

--- a/mifos-authenticator-biometrics/src/desktopMain/kotlin/org/mifos/authenticator/biometrics/mockServer/utils/Helpers.kt
+++ b/mifos-authenticator-biometrics/src/desktopMain/kotlin/org/mifos/authenticator/biometrics/mockServer/utils/Helpers.kt
@@ -30,9 +30,5 @@ fun generateRandomUID(): String {
 }
 
 fun generateBase64EncodedUID(userId: String): String {
-    val secureRandom = SecureRandom()
-    val userIDBytes = userId.toByteArray()
-    secureRandom.nextBytes(userIDBytes)
-
-    return Base64UrlUtil.encodeToString(userIDBytes)
+    return Base64UrlUtil.encodeToString(userId.toByteArray(Charsets.UTF_8))
 }

--- a/mifos-authenticator-biometrics/src/desktopMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
+++ b/mifos-authenticator-biometrics/src/desktopMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
@@ -58,19 +58,23 @@ actual class PlatformAuthenticator private actual constructor() {
                 displayName,
             )
 
-            if (windowsAuthResponse is WindowsAuthenticatorResponse.Registration.Error) {
-                return RegistrationResult.Error("Error while registering user")
-            }
-            val response = (windowsAuthResponse as WindowsAuthenticatorResponse.Registration.Success)
-                .response.windowsAuthenticationResponse
-            return if (response == WindowsAuthenticationResponse.SUCCESS) {
-                RegistrationResult.Success(
-                    encodeWindowsAuthenticatorToJsonString(
-                        windowsAuthResponse.response,
-                    ),
-                )
-            } else {
-                returnRegistrationResult(windowsAuthResponse.response)
+            when (windowsAuthResponse) {
+                is WindowsAuthenticatorResponse.Registration.UserCancelled ->
+                    return RegistrationResult.UserCancelled
+                is WindowsAuthenticatorResponse.Registration.Error ->
+                    return RegistrationResult.Error("Error while registering user")
+                is WindowsAuthenticatorResponse.Registration.Success -> {
+                    val response = windowsAuthResponse.response.windowsAuthenticationResponse
+                    return if (response == WindowsAuthenticationResponse.SUCCESS) {
+                        RegistrationResult.Success(
+                            encodeWindowsAuthenticatorToJsonString(
+                                windowsAuthResponse.response,
+                            ),
+                        )
+                    } else {
+                        returnRegistrationResult(windowsAuthResponse.response)
+                    }
+                }
             }
         }
         return RegistrationResult.PlatformAuthenticatorNotAvailable
@@ -87,12 +91,14 @@ actual class PlatformAuthenticator private actual constructor() {
                     windowsRegistrationResponse,
                 )
 
-            if (windowsAuthResponse is WindowsAuthenticatorResponse.Verification.Error) {
-                return AuthenticationResult.Error("Error while registering user")
+            when (windowsAuthResponse) {
+                is WindowsAuthenticatorResponse.Verification.UserCancelled ->
+                    return AuthenticationResult.UserCancelled
+                is WindowsAuthenticatorResponse.Verification.Error ->
+                    return AuthenticationResult.Error("Error while verifying user")
+                is WindowsAuthenticatorResponse.Verification.Success ->
+                    return returnAuthenticatorResult(windowsAuthResponse.response)
             }
-
-            val response = (windowsAuthResponse as WindowsAuthenticatorResponse.Verification.Success).response
-            return returnAuthenticatorResult(response)
         }
 
         return AuthenticationResult.UserNotRegistered
@@ -108,7 +114,8 @@ fun returnAuthenticatorResult(windowsAuthenticatorResponse: WindowsAuthenticatio
         )
         WindowsAuthenticationResponse.E_FAILURE -> AuthenticationResult.Error(windowsAuthenticatorResponse.name)
         WindowsAuthenticationResponse.ABORTED -> AuthenticationResult.Error(windowsAuthenticatorResponse.name)
-        WindowsAuthenticationResponse.USER_CANCELED -> AuthenticationResult.Error(windowsAuthenticatorResponse.name)
+        // Already handled via Verification.UserCancelled upstream; required for exhaustive when.
+        WindowsAuthenticationResponse.USER_CANCELED -> AuthenticationResult.UserCancelled
         WindowsAuthenticationResponse.REGISTER_AGAIN -> AuthenticationResult.UserNotRegistered
         WindowsAuthenticationResponse.UNKNOWN_ERROR -> AuthenticationResult.Error(windowsAuthenticatorResponse.name)
         WindowsAuthenticationResponse.INVALID_PARAMETER -> AuthenticationResult.Error(
@@ -134,9 +141,8 @@ fun returnRegistrationResult(windowsRegistrationResponse: WindowsRegistrationRes
         WindowsAuthenticationResponse.ABORTED -> RegistrationResult.Error(
             windowsRegistrationResponse.windowsAuthenticationResponse.name,
         )
-        WindowsAuthenticationResponse.USER_CANCELED -> RegistrationResult.Error(
-            windowsRegistrationResponse.windowsAuthenticationResponse.name,
-        )
+        // Already handled via Registration.UserCancelled upstream; required for exhaustive when.
+        WindowsAuthenticationResponse.USER_CANCELED -> RegistrationResult.UserCancelled
         WindowsAuthenticationResponse.REGISTER_AGAIN -> RegistrationResult.PlatformAuthenticatorNotSet
         WindowsAuthenticationResponse.UNKNOWN_ERROR -> RegistrationResult.Error(
             windowsRegistrationResponse.windowsAuthenticationResponse.name,

--- a/mifos-authenticator-biometrics/src/desktopMain/kotlin/org/mifos/authenticator/biometrics/windows/WindowsHelloAuthenticator.kt
+++ b/mifos-authenticator-biometrics/src/desktopMain/kotlin/org/mifos/authenticator/biometrics/windows/WindowsHelloAuthenticator.kt
@@ -9,6 +9,7 @@
  */
 package org.mifos.authenticator.biometrics.windows
 
+import co.touchlab.kermit.Logger
 import com.sun.jna.Memory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -86,7 +87,6 @@ class WindowsHelloAuthenticator(
     ): WindowsAuthenticatorResponse.Registration {
         return withContext(Dispatchers.IO) {
             val challenge = generateChallenge()
-            println(challenge)
 
             val registrationDataGET = RegistrationDataGET.ByReference()
 
@@ -136,6 +136,7 @@ class WindowsHelloAuthenticator(
                     WindowsAuthenticatorResponse.Registration.Success(windowsRegistrationResponse)
                 }
             } catch (e: Exception) {
+                Logger.e(e) { "Windows Hello registration/verification failed" }
                 WindowsAuthenticatorResponse.Registration.Error(e.localizedMessage)
             } finally {
                 registrationDataPOST?.let {

--- a/mifos-authenticator-biometrics/src/desktopMain/kotlin/org/mifos/authenticator/biometrics/windows/WindowsHelloAuthenticator.kt
+++ b/mifos-authenticator-biometrics/src/desktopMain/kotlin/org/mifos/authenticator/biometrics/windows/WindowsHelloAuthenticator.kt
@@ -59,6 +59,7 @@ sealed class WindowsAuthenticatorResponse {
     sealed class Registration {
         class Success(val response: WindowsRegistrationResponse) : Registration()
         data class Error(val message: String) : Registration()
+
         // Handled early in invokeUserRegistration() before attestation bytes are checked,
         // because a cancelled registration returns null bytes from native code which would
         // otherwise be misinterpreted as a generic error.
@@ -67,6 +68,7 @@ sealed class WindowsAuthenticatorResponse {
     sealed class Verification {
         class Success(val response: WindowsAuthenticationResponse) : Verification()
         data object Error : Verification()
+
         // Handled early in invokeUserVerification() for consistency with Registration.
         data object UserCancelled : Verification()
     }

--- a/mifos-authenticator-biometrics/src/desktopMain/kotlin/org/mifos/authenticator/biometrics/windows/WindowsHelloAuthenticator.kt
+++ b/mifos-authenticator-biometrics/src/desktopMain/kotlin/org/mifos/authenticator/biometrics/windows/WindowsHelloAuthenticator.kt
@@ -58,10 +58,16 @@ sealed class WindowsAuthenticatorResponse {
     sealed class Registration {
         class Success(val response: WindowsRegistrationResponse) : Registration()
         data class Error(val message: String) : Registration()
+        // Handled early in invokeUserRegistration() before attestation bytes are checked,
+        // because a cancelled registration returns null bytes from native code which would
+        // otherwise be misinterpreted as a generic error.
+        data object UserCancelled : Registration()
     }
     sealed class Verification {
         class Success(val response: WindowsAuthenticationResponse) : Verification()
         data object Error : Verification()
+        // Handled early in invokeUserVerification() for consistency with Registration.
+        data object UserCancelled : Verification()
     }
 }
 
@@ -103,6 +109,11 @@ class WindowsHelloAuthenticator(
             try {
                 registrationDataPOST = windowsHelloAuthenticator.registerUser(registrationDataGET)
 
+                val authResult = registrationDataPOST.getAuthenticationResult()
+                if (authResult == WindowsAuthenticationResponse.USER_CANCELED) {
+                    return@withContext WindowsAuthenticatorResponse.Registration.UserCancelled
+                }
+
                 val attestationObject = registrationDataPOST.getAttestationObjectBytes()
                 val credentialIdBytes = registrationDataPOST.getCredentialIDBytes()
 
@@ -120,7 +131,7 @@ class WindowsHelloAuthenticator(
                         (credentialIdBytes as RetrievedDataFromAuthenticator.Success).bytes,
                         credentialIdLength = registrationDataPOST.credentialIdLength,
                         userId = registrationDataGET.userID,
-                        windowsAuthenticationResponse = registrationDataPOST.getAuthenticationResult(),
+                        windowsAuthenticationResponse = authResult,
                     )
                     WindowsAuthenticatorResponse.Registration.Success(windowsRegistrationResponse)
                 }
@@ -169,7 +180,11 @@ class WindowsHelloAuthenticator(
                 verificationDataPOST = windowsHelloAuthenticator.verifyUser(verificationDataGET)
 
                 val verificationResponse = verificationDataPOST.getVerificationResult()
-                WindowsAuthenticatorResponse.Verification.Success(verificationResponse)
+                if (verificationResponse == WindowsAuthenticationResponse.USER_CANCELED) {
+                    WindowsAuthenticatorResponse.Verification.UserCancelled
+                } else {
+                    WindowsAuthenticatorResponse.Verification.Success(verificationResponse)
+                }
             } catch (e: Exception) {
                 e.printStackTrace()
                 WindowsAuthenticatorResponse.Verification.Error

--- a/mifos-authenticator-biometrics/src/iosMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
+++ b/mifos-authenticator-biometrics/src/iosMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
@@ -17,6 +17,7 @@ import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
 import kotlinx.coroutines.suspendCancellableCoroutine
+import org.mifos.authenticator.biometrics.platformAuthenticator.RegistrationResult.*
 import platform.Foundation.NSError
 import platform.Foundation.NSURL
 import platform.LocalAuthentication.LAContext
@@ -24,6 +25,7 @@ import platform.LocalAuthentication.LAErrorBiometryLockout
 import platform.LocalAuthentication.LAErrorBiometryNotAvailable
 import platform.LocalAuthentication.LAErrorBiometryNotEnrolled
 import platform.LocalAuthentication.LAErrorPasscodeNotSet
+import platform.LocalAuthentication.LAErrorUserCancel
 import platform.LocalAuthentication.LAPolicyDeviceOwnerAuthentication
 import platform.LocalAuthentication.LAPolicyDeviceOwnerAuthenticationWithBiometrics
 import platform.UIKit.UIApplication
@@ -92,9 +94,10 @@ actual class PlatformAuthenticator private actual constructor() {
         displayName: String,
     ): RegistrationResult {
         return when (val result = authenticate("Register yourself", null)) {
-            is AuthenticationResult.Success -> RegistrationResult.Success("")
-            is AuthenticationResult.Error -> RegistrationResult.Error(result.message)
+            is AuthenticationResult.Success -> Success("")
+            is AuthenticationResult.Error -> Error(result.message)
             is AuthenticationResult.UserNotRegistered -> RegistrationResult.PlatformAuthenticatorNotSet
+            AuthenticationResult.UserCancelled -> UserCancelled
         }
     }
 
@@ -111,8 +114,12 @@ actual class PlatformAuthenticator private actual constructor() {
             if (success) {
                 continuation.resume(AuthenticationResult.Success)
             } else {
-                val message = error?.localizedDescription ?: "Authentication failed."
-                continuation.resume(AuthenticationResult.Error(message))
+                if(error?.code == LAErrorUserCancel) {
+                    continuation.resume(AuthenticationResult.UserCancelled)
+                } else{
+                    val message = error?.localizedDescription ?: "Authentication failed."
+                    continuation.resume(AuthenticationResult.Error(message))
+                }
             }
         }
     }

--- a/mifos-authenticator-biometrics/src/iosMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
+++ b/mifos-authenticator-biometrics/src/iosMain/kotlin/org/mifos/authenticator/biometrics/platformAuthenticator/PlatformAuthenticator.kt
@@ -17,7 +17,9 @@ import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
 import kotlinx.coroutines.suspendCancellableCoroutine
-import org.mifos.authenticator.biometrics.platformAuthenticator.RegistrationResult.*
+import org.mifos.authenticator.biometrics.platformAuthenticator.RegistrationResult.Error
+import org.mifos.authenticator.biometrics.platformAuthenticator.RegistrationResult.Success
+import org.mifos.authenticator.biometrics.platformAuthenticator.RegistrationResult.UserCancelled
 import platform.Foundation.NSError
 import platform.Foundation.NSURL
 import platform.LocalAuthentication.LAContext
@@ -114,9 +116,9 @@ actual class PlatformAuthenticator private actual constructor() {
             if (success) {
                 continuation.resume(AuthenticationResult.Success)
             } else {
-                if(error?.code == LAErrorUserCancel) {
+                if (error?.code == LAErrorUserCancel) {
                     continuation.resume(AuthenticationResult.UserCancelled)
-                } else{
+                } else {
                     val message = error?.localizedDescription ?: "Authentication failed."
                     continuation.resume(AuthenticationResult.Error(message))
                 }


### PR DESCRIPTION
## Fix: Propagate `UserCancelled` across all platforms & clean up biometrics bugs

### Problem

When a user dismissed the biometric prompt on **any platform**, the cancellation was incorrectly reported as a generic `AuthenticationResult.Error`. This caused misleading error dialogs (e.g. `"10: authentication cancelled"` on Android) instead of silently returning to the passcode screen.

### Changes

- **Added `UserCancelled` to `AuthenticationResult` and `RegistrationResult`** sealed interfaces so all platforms can distinguish cancellation from actual errors.
- **Android:** Map `ERROR_USER_CANCELED`, `ERROR_CANCELED`, `ERROR_NEGATIVE_BUTTON` to `UserCancelled` in `onAuthenticationError`. Replace dead code in `onAuthenticationFailed()` with `Logger.w`.
- **iOS:** Map `LAErrorUserCancel` to `UserCancelled` in `authenticate()`. Handle `UserCancelled` in `registerUser()`.
- **Windows:** Add `UserCancelled` variant to `WindowsAuthenticatorResponse.Registration` and `Verification`. Intercept `USER_CANCELED` early in `invokeUserRegistration()` before attestation bytes check (native returns null bytes on cancel, which was misinterpreted as a generic error). Update mapping functions in `PlatformAuthenticator`.
- **Sample app:** Handle `UserCancelled` in `BiometricKey`, `HomeScreen`, and `BiometricSetupScreen` as a no-op.
- **Bug fix:** `generateBase64EncodedUID()` was overwriting the userId with random bytes. Removed the erroneous `secureRandom.nextBytes()` call.
- **Cleanup:** Replace `println` debug statements with `Logger.d`/`Logger.w` in Android `PlatformAuthenticator` and `PlatformAvailableAuthenticationOption`. Add `Logger.e` for Windows exception handlers. Remove wildcard imports flagged by ktlint.

### Before / After

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/793f94a7-2f81-4b1c-9a80-5bf32f006032"/> | <video src="https://github.com/user-attachments/assets/b4d0f640-d0b6-4dff-946d-db4ab1fabebc" /> |
