### PR TITLE
Decouple passcode and biometrics libraries                                                                                                                                                                                                                                                                                                

### DIFF
--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/BiometricStorageAdapterImpl.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/BiometricStorageAdapterImpl.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
+ */
+package cmp.sample.shared
+
+import com.russhwolf.settings.Settings
+import org.mifos.authenticator.biometrics.BiometricStorageAdapter
+
+private const val REGISTRATION_DATA_KEY = "org.mifos.authenticator.registration_data"
+
+class BiometricStorageAdapterImpl(
+    private val settings: Settings,
+) : BiometricStorageAdapter {
+    override fun saveRegistrationData(registrationData: String) {
+        settings.putString(REGISTRATION_DATA_KEY, registrationData)
+    }
+
+    override fun loadRegistrationData(): String? {
+        return settings.getStringOrNull(REGISTRATION_DATA_KEY)
+    }
+
+    override fun deleteRegistrationData() {
+        settings.remove(REGISTRATION_DATA_KEY)
+    }
+}

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/PasscodeStorageAdapterImpl.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/PasscodeStorageAdapterImpl.kt
@@ -12,8 +12,7 @@ package cmp.sample.shared
 import com.russhwolf.settings.Settings
 import org.mifos.authenticator.passcode.PasscodeStorageAdapter
 
-const val PASSCODE_KEY = "org.mifos.authenticator.passcode"
-const val REGISTRATION_DATA_KEY = "org.mifos.authenticator.registration_data"
+private const val PASSCODE_KEY = "org.mifos.authenticator.passcode"
 
 class PasscodeStorageAdapterImpl(
     private val settings: Settings,
@@ -30,15 +29,12 @@ class PasscodeStorageAdapterImpl(
         settings.remove(PASSCODE_KEY)
     }
 
-    override fun saveRegistrationData(registrationData: String) {
-        settings.putString(REGISTRATION_DATA_KEY, registrationData)
-    }
+    @Suppress("DEPRECATION")
+    override fun saveRegistrationData(registrationData: String) { }
 
-    override fun loadRegistrationData(): String? {
-        return settings.getStringOrNull(REGISTRATION_DATA_KEY)
-    }
+    @Suppress("DEPRECATION")
+    override fun loadRegistrationData(): String? = null
 
-    override fun deleteRegistrationData() {
-        settings.remove(REGISTRATION_DATA_KEY)
-    }
+    @Suppress("DEPRECATION")
+    override fun deleteRegistrationData() { }
 }

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/di/PasscodeModule.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/di/PasscodeModule.kt
@@ -9,6 +9,7 @@
  */
 package cmp.sample.shared.di
 
+import cmp.sample.shared.BiometricStorageAdapterImpl
 import cmp.sample.shared.PasscodeStorageAdapterImpl
 import com.russhwolf.settings.Settings
 import kotlinx.coroutines.MainScope
@@ -17,13 +18,17 @@ import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.KoinAppDeclaration
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.mifos.authenticator.biometrics.BiometricStorageAdapter
 import org.mifos.authenticator.passcode.PasscodeManager
 import org.mifos.authenticator.passcode.PasscodeStorageAdapter
 
 val passcodeModule = module {
     singleOf(::PasscodeStorageAdapterImpl).bind<PasscodeStorageAdapter>()
+    singleOf(::BiometricStorageAdapterImpl).bind<BiometricStorageAdapter>()
     single {
-        PasscodeManager(get(), MainScope()).initialize()
+        val biometricAdapter = get<BiometricStorageAdapter>()
+        val isExternalAuthEnabled = biometricAdapter.loadRegistrationData() != null
+        PasscodeManager(get(), MainScope()).initialize(isExternalAuthEnabled)
     }
     single { Settings() }
 }

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
@@ -41,6 +41,7 @@ import cmp.sample.shared.ui.components.DialogBoxType
 import cmp.sample.shared.ui.components.MessageDialogBox
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import org.mifos.authenticator.biometrics.BiometricStorageAdapter
 import org.mifos.authenticator.biometrics.platformAuthenticationProvider
 import org.mifos.authenticator.biometrics.platformAuthenticator.AuthenticationResult
 import org.mifos.authenticator.biometrics.platformAuthenticator.PlatformAuthOptions
@@ -56,6 +57,7 @@ import org.mifos.authenticator.passcode.screen.PasscodeScreen
 @Composable
 fun SampleAppNavigation(
     passcodeStorageAdapter: PasscodeStorageAdapter = koinInject(),
+    biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
 ) {
     val navController = rememberNavController()
 
@@ -90,6 +92,7 @@ fun SampleAppNavigation(
                     }
                 },
                 onForgotButton = {
+                    biometricStorageAdapter.deleteRegistrationData()
                     navController.navigate(Route.LoginScreen) {
                         popUpTo(0)
                     }
@@ -102,15 +105,16 @@ fun SampleAppNavigation(
                         popUpTo(0)
                     }
                 },
-                onDisableBiometrics = {
+                onDisableExternalAuth = {
+                    biometricStorageAdapter.deleteRegistrationData()
                     navController.popBackStack()
                 },
                 onPasscodeRejected = {},
-                onBiometricError = { message ->
+                onExternalAuthError = { message ->
                     dialogBoxType = DialogBoxType.ERROR
-                    dialogMessage = message ?: "Biometric authentication failed"
+                    dialogMessage = message ?: "Authentication failed"
                 },
-                biometricButton = { modifier ->
+                externalAuthButton = { modifier ->
                     BiometricKey(
                         modifier = modifier,
                         passcodeManager = passcodeManager,
@@ -194,7 +198,7 @@ fun BiometricKey(
     modifier: Modifier,
     passcodeManager: PasscodeManager,
     onUserNotRegistered: () -> Unit,
-    passcodeStorageAdapter: PasscodeStorageAdapter = koinInject(),
+    biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
 ) {
     val platformAuthenticationProvider = platformAuthenticationProvider.current
     val platformAvailableAuthenticationOption = platformAvailableAuthenticationOption.current
@@ -219,15 +223,15 @@ fun BiometricKey(
                 scope.launch {
                     val result = platformAuthenticationProvider.onAuthenticatorClick(
                         "Unlock with Biometrics",
-                        passcodeStorageAdapter.loadRegistrationData() ?: "",
+                        biometricStorageAdapter.loadRegistrationData() ?: "",
                     )
                     when (result) {
                         is AuthenticationResult.Success -> {
-                            passcodeManager.trySendAction(PasscodeAction.BiometricUnlockSuccess)
+                            passcodeManager.trySendAction(PasscodeAction.ExternalUnlockSuccess)
                         }
                         is AuthenticationResult.Error -> {
                             passcodeManager.trySendAction(
-                                PasscodeAction.BiometricUnlockFailure(
+                                PasscodeAction.ExternalUnlockFailure(
                                     result.message,
                                 ),
                             )
@@ -279,6 +283,7 @@ fun HomeScreen(
     onEnableBiometricsSuccess: () -> Unit,
     onBiometricsEnableError: (String) -> Unit,
     passcodeManager: PasscodeManager = koinInject<PasscodeManager>(),
+    biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
 ) {
     val state by passcodeManager.state.collectAsState()
     val platformAuthenticationProvider = platformAuthenticationProvider.current
@@ -298,6 +303,7 @@ fun HomeScreen(
 
         Button(
             onClick = {
+                biometricStorageAdapter.deleteRegistrationData()
                 passcodeManager.trySendAction(PasscodeAction.LogOutErasePasscode)
                 onLogoutClick()
             },
@@ -325,9 +331,9 @@ fun HomeScreen(
 
             Button(
                 onClick = {
-                    if (state.isBiometricEnabled) {
+                    if (state.isExternalAuthEnabled) {
                         // Disabling: should require passcode verification
-                        passcodeManager.trySendAction(PasscodeAction.DisableBiometrics)
+                        passcodeManager.trySendAction(PasscodeAction.DisableExternalAuth)
                         navigateToPasscodeScreen()
                     } else {
                         scope.launch {
@@ -338,11 +344,12 @@ fun HomeScreen(
                             )
                             when (result) {
                                 is RegistrationResult.Success -> {
-                                    passcodeManager.trySendAction(PasscodeAction.SaveBiometricRegistration(result.message))
+                                    biometricStorageAdapter.saveRegistrationData(result.message)
+                                    passcodeManager.trySendAction(PasscodeAction.SaveExternalRegistration(result.message))
                                     onEnableBiometricsSuccess()
                                 }
                                 RegistrationResult.PlatformAuthenticatorNotSet -> {
-                                    passcodeManager.trySendAction(PasscodeAction.BiometricUserNotRegistered)
+                                    passcodeManager.trySendAction(PasscodeAction.ExternalAuthNotAvailable)
                                     onBiometricsEnableError("Biometrics are not set up on this device. Please enable fingerprint or face unlock in your device settings, then try again.")
                                 }
                                 RegistrationResult.PlatformAuthenticatorNotAvailable -> {
@@ -358,7 +365,7 @@ fun HomeScreen(
                 },
             ) {
                 Text(
-                    if (state.isBiometricEnabled) "Disable Biometrics" else "Enable Biometrics",
+                    if (state.isExternalAuthEnabled) "Disable Biometrics" else "Enable Biometrics",
                 )
             }
         }

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/BiometricSetupScreen.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/BiometricSetupScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.sp
 import cmp.sample.shared.theme.blueTint
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import org.mifos.authenticator.biometrics.BiometricStorageAdapter
 import org.mifos.authenticator.biometrics.platformAuthenticationProvider
 import org.mifos.authenticator.biometrics.platformAuthenticator.RegistrationResult
 import org.mifos.authenticator.passcode.PasscodeAction
@@ -49,6 +50,7 @@ fun BiometricSetupScreen(
     onSkipBiometricSetup: () -> Unit,
     onError: (String) -> Unit,
     passcodeManager: PasscodeManager = koinInject(),
+    biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
 ) {
     val platformAuthenticationProvider = platformAuthenticationProvider.current
     val scope = rememberCoroutineScope()
@@ -102,11 +104,12 @@ fun BiometricSetupScreen(
                         )
                         when (result) {
                             is RegistrationResult.Success -> {
-                                passcodeManager.trySendAction(PasscodeAction.SaveBiometricRegistration(result.message))
+                                biometricStorageAdapter.saveRegistrationData(result.message)
+                                passcodeManager.trySendAction(PasscodeAction.SaveExternalRegistration(result.message))
                                 onBiometricsRegistrationSuccess()
                             }
                             RegistrationResult.PlatformAuthenticatorNotSet -> {
-                                passcodeManager.trySendAction(PasscodeAction.BiometricUserNotRegistered)
+                                passcodeManager.trySendAction(PasscodeAction.ExternalAuthNotAvailable)
                                 onError("Biometrics are not set up on this device. Please enable fingerprint or face unlock in your device settings, then try again.")
                             }
                             RegistrationResult.PlatformAuthenticatorNotAvailable -> {

--- a/mifos-authenticator-biometrics/src/commonMain/kotlin/org/mifos/authenticator/biometrics/BiometricStorageAdapter.kt
+++ b/mifos-authenticator-biometrics/src/commonMain/kotlin/org/mifos/authenticator/biometrics/BiometricStorageAdapter.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
+ */
+package org.mifos.authenticator.biometrics
+
+/**
+ * An interface for persisting biometric registration data (e.g. FIDO/WebAuthn credentials).
+ *
+ * Implementations should store data securely using platform-appropriate mechanisms
+ * (e.g. EncryptedSharedPreferences on Android, Keychain on iOS).
+ */
+interface BiometricStorageAdapter {
+    /**
+     * Saves biometric registration data to persistent storage.
+     *
+     * @param registrationData The registration data string to be saved.
+     */
+    fun saveRegistrationData(registrationData: String)
+
+    /**
+     * Loads the stored biometric registration data from persistent storage.
+     *
+     * @return The loaded registration data, or `null` if none is stored.
+     */
+    fun loadRegistrationData(): String?
+
+    /**
+     * Deletes the biometric registration data from persistent storage.
+     */
+    fun deleteRegistrationData()
+}

--- a/mifos-authenticator-passcode/src/commonMain/composeResources/values/strings.xml
+++ b/mifos-authenticator-passcode/src/commonMain/composeResources/values/strings.xml
@@ -23,8 +23,8 @@
     <string name="drag_guide">drag_guide</string>
     <string name="drag_passcode">drag_passcode</string>
     <string name="drag_your_pattern">drag_your_pattern</string>
-    <string name="enable_biometric_dialog_description">enable_biometric_dialog_description</string>
-    <string name="enable_biometric_dialog_title">enable_biometric_dialog_title</string>
+    <string name="enable_external_auth_dialog_description">enable_external_auth_dialog_description</string>
+    <string name="enable_external_auth_dialog_title">enable_external_auth_dialog_title</string>
     <string name="enter_your_passcode">Enter your passcode</string>
     <string name="exit">Exit</string>
     <string name="forgot_passcode">Forgot Passcode?</string>

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
@@ -30,15 +30,17 @@ import org.mifos.authenticator.passcode.utility.PasscodeLength
  *
  * @param adapter The [PasscodeStorageAdapter] to use for persisting and loading passcodes.
  * @param scope The [CoroutineScope] to launch coroutines for handling passcode actions and events.
+ * @param isExternalAuthEnabled Whether external authentication (e.g. biometrics) is registered.
  * @return An initialized [PasscodeManager] instance.
  */
 @Composable
 fun rememberPasscodeManager(
     adapter: PasscodeStorageAdapter,
     scope: CoroutineScope,
+    isExternalAuthEnabled: Boolean = false,
 ): PasscodeManager {
     return remember(scope) {
-        PasscodeManager(adapter, scope).initialize()
+        PasscodeManager(adapter, scope).initialize(isExternalAuthEnabled)
     }
 }
 
@@ -49,9 +51,9 @@ fun rememberPasscodeManager(
  * - Initial passcode setup (Creation and Confirmation)
  * - Passcode verification for app unlock
  * - Changing the existing passcode
- * - Enabling/Disabling biometric authentication
+ * - Enabling/Disabling external authentication (e.g. biometrics)
  *
- * @property adapter The storage adapter used for persisting passcode and biometric data.
+ * @property adapter The storage adapter used for persisting passcode and external auth data.
  * @property scope Coroutine scope for internal processing and event emission.
  */
 class PasscodeManager(
@@ -100,11 +102,12 @@ class PasscodeManager(
      *
      * Should be called once after creation, especially when not using [rememberPasscodeManager].
      *
+     * @param isExternalAuthEnabled Whether external authentication (e.g. biometrics) is registered.
+     *        The caller should check this via their own storage (e.g. [BiometricStorageAdapter]).
      * @return The initialized [PasscodeManager] instance.
      */
-    fun initialize(): PasscodeManager {
+    fun initialize(isExternalAuthEnabled: Boolean = false): PasscodeManager {
         val loaded = adapter.loadPasscode()
-        val biometricRegistered = adapter.loadRegistrationData() != null
 
         when {
             loaded != null -> {
@@ -112,7 +115,7 @@ class PasscodeManager(
                     it.copy(
                         loadedPasscode = loaded,
                         passcodeStep = PasscodeStep.Enter,
-                        isBiometricEnabled = biometricRegistered,
+                        isExternalAuthEnabled = isExternalAuthEnabled,
                     )
                 }
                 updatePasscodeLength(
@@ -128,7 +131,7 @@ class PasscodeManager(
                 updateState {
                     it.copy(
                         passcodeStep = PasscodeStep.Create,
-                        isBiometricEnabled = biometricRegistered,
+                        isExternalAuthEnabled = isExternalAuthEnabled,
                     )
                 }
             }
@@ -139,7 +142,7 @@ class PasscodeManager(
     private fun handleAction(action: PasscodeAction) {
         when (action) {
             PasscodeAction.ChangePasscode -> changePasscode()
-            PasscodeAction.DisableBiometrics -> disableBiometrics()
+            PasscodeAction.DisableExternalAuth -> disableExternalAuth()
             PasscodeAction.DeleteAllKeys -> deleteAllKeys()
             PasscodeAction.DeleteKey -> deleteKey()
             is PasscodeAction.EnterKey -> enterKey(action.key)
@@ -155,27 +158,26 @@ class PasscodeManager(
             PasscodeAction.LogOutErasePasscode -> {
                 clearAllSecurityData()
             }
-            PasscodeAction.BiometricUnlockSuccess -> {
+            PasscodeAction.ExternalUnlockSuccess -> {
                 if (_state.value.passcodeStep == PasscodeStep.Enter) {
                     emitEvent(PasscodeEvent.OnUnlockSuccess)
                 }
             }
-            is PasscodeAction.BiometricUnlockFailure -> {
+            is PasscodeAction.ExternalUnlockFailure -> {
                 if (_state.value.passcodeStep == PasscodeStep.Enter) {
-                    emitEvent(PasscodeEvent.OnBiometricUnlockFailure(action.message))
+                    emitEvent(PasscodeEvent.OnExternalUnlockFailure(action.message))
                 }
             }
-            PasscodeAction.BiometricUserNotRegistered -> {
-                clearBiometricRegistration()
+            PasscodeAction.ExternalAuthNotAvailable -> {
+                clearExternalRegistration()
                 if (_state.value.passcodeStep == PasscodeStep.Enter) {
-                    emitEvent(PasscodeEvent.OnBiometricUserNotRegistered)
+                    emitEvent(PasscodeEvent.OnExternalAuthNotAvailable)
                 }
             }
-            is PasscodeAction.SaveBiometricRegistration -> {
-                adapter.saveRegistrationData(action.registrationData)
-                updateState { it.copy(isBiometricEnabled = true) }
+            is PasscodeAction.SaveExternalRegistration -> {
+                updateState { it.copy(isExternalAuthEnabled = true) }
             }
-            PasscodeAction.DeleteBiometricRegistration -> clearBiometricRegistration()
+            PasscodeAction.DeleteExternalRegistration -> clearExternalRegistration()
         }
     }
 
@@ -228,14 +230,14 @@ class PasscodeManager(
         updateState { it.copy(passcodeStep = PasscodeStep.ChangeVerify, isChangeFlow = true) }
     }
 
-    private fun disableBiometrics() {
-        updateState { it.copy(passcodeStep = PasscodeStep.DisableBiometrics) }
+    private fun disableExternalAuth() {
+        updateState { it.copy(passcodeStep = PasscodeStep.DisableExternalAuth) }
     }
 
     private fun handleCompletedPasscodeEntry() {
         when (_state.value.passcodeStep) {
             PasscodeStep.ChangeVerify -> handleChangeVerifyPasscode()
-            PasscodeStep.DisableBiometrics -> handleDisableBiometricsVerification()
+            PasscodeStep.DisableExternalAuth -> handleDisableExternalAuthVerification()
             PasscodeStep.Enter -> handleEnterPasscode()
             PasscodeStep.Create -> handleCreatePasscode()
             PasscodeStep.Confirm -> handleConfirmPasscode()
@@ -248,7 +250,7 @@ class PasscodeManager(
             PasscodeStep.ChangeVerify,
             PasscodeStep.Confirm,
             PasscodeStep.Enter,
-            PasscodeStep.DisableBiometrics,
+            PasscodeStep.DisableExternalAuth,
             -> finalConfirmationPasscodeBuilder
             else -> creationPasscodeBuilder
         }
@@ -273,12 +275,12 @@ class PasscodeManager(
         resetPasscodeEntryStates()
     }
 
-    private fun handleDisableBiometricsVerification() {
+    private fun handleDisableExternalAuthVerification() {
         val loadedPasscode = adapter.loadPasscode()
         if (finalConfirmationPasscodeBuilder.toString() == loadedPasscode) {
-            clearBiometricRegistration()
+            clearExternalRegistration()
             updateState { it.copy(passcodeStep = PasscodeStep.Enter) }
-            emitEvent(PasscodeEvent.OnDisableBiometricsSuccess)
+            emitEvent(PasscodeEvent.OnDisableExternalAuthSuccess)
         } else {
             emitEvent(PasscodeEvent.OnRejectEnteredPasscode)
         }
@@ -352,14 +354,13 @@ class PasscodeManager(
     private fun clearAllSecurityData() {
         adapter.deletePasscode()
         updateState { it.copy(loadedPasscode = null, passcodeStep = PasscodeStep.Create) }
-        clearBiometricRegistration()
+        clearExternalRegistration()
         resetPasscodeEntryStates()
     }
 
-    private fun clearBiometricRegistration() {
-        adapter.deleteRegistrationData()
+    private fun clearExternalRegistration() {
         updateState {
-            it.copy(isBiometricEnabled = false)
+            it.copy(isExternalAuthEnabled = false)
         }
         resetPasscodeEntryStates()
     }
@@ -392,7 +393,7 @@ class PasscodeManager(
  * @property loadedPasscode The saved passcode from storage (null if not set).
  * @property passcodeStep The current step in the passcode flow (e.g., Enter, Create, Confirm).
  * @property isChangeFlow Whether the user is currently in the process of changing their passcode.
- * @property isBiometricEnabled Whether biometric authentication is enabled and registered.
+ * @property isExternalAuthEnabled Whether external authentication (e.g. biometrics) is enabled and registered.
  */
 data class PasscodeState(
     val filledDots: Int = 0,
@@ -402,14 +403,14 @@ data class PasscodeState(
     val loadedPasscode: String? = null,
     val passcodeStep: PasscodeStep = PasscodeStep.Unset,
     val isChangeFlow: Boolean = false,
-    val isBiometricEnabled: Boolean = false,
+    val isExternalAuthEnabled: Boolean = false,
 )
 
 /**
  * Events emitted by the [PasscodeManager] to notify the UI or other components of state changes.
  */
 sealed interface PasscodeEvent {
-    /** Emitted when the passcode or biometric authentication is successful. */
+    /** Emitted when the passcode or external authentication is successful. */
     object OnUnlockSuccess : PasscodeEvent
 
     /** Emitted when a new passcode is successfully created and confirmed for the first time. */
@@ -418,8 +419,8 @@ sealed interface PasscodeEvent {
     /** Emitted when an existing passcode is successfully changed. */
     object OnPasscodeChanged : PasscodeEvent
 
-    /** Emitted when biometric authentication is successfully disabled. */
-    object OnDisableBiometricsSuccess : PasscodeEvent
+    /** Emitted when external authentication is successfully disabled. */
+    object OnDisableExternalAuthSuccess : PasscodeEvent
 
     /** Emitted when an incorrect passcode is entered during the unlock or change verification flow. */
     object OnRejectEnteredPasscode : PasscodeEvent
@@ -431,13 +432,13 @@ sealed interface PasscodeEvent {
     object OnPasscodeDeletion : PasscodeEvent
 
     /**
-     * Emitted when biometric authentication fails.
+     * Emitted when external authentication fails.
      * @property message An optional error message explaining the failure.
      */
-    data class OnBiometricUnlockFailure(val message: String?) : PasscodeEvent
+    data class OnExternalUnlockFailure(val message: String?) : PasscodeEvent
 
-    /** Emitted when a biometric unlock is attempted but the user is not registered. */
-    object OnBiometricUserNotRegistered : PasscodeEvent
+    /** Emitted when an external unlock is attempted but the user is not registered. */
+    object OnExternalAuthNotAvailable : PasscodeEvent
 }
 
 /**
@@ -491,29 +492,29 @@ sealed interface PasscodeAction {
      */
     data class UpdatePasscodeLength(val length: PasscodeLength) : PasscodeAction
 
-    /** Signals a successful biometric authentication. */
-    object BiometricUnlockSuccess : PasscodeAction
+    /** Signals a successful external authentication (e.g. biometrics). */
+    object ExternalUnlockSuccess : PasscodeAction
 
     /**
-     * Signals a failed biometric authentication.
+     * Signals a failed external authentication.
      * @property message An optional error message.
      */
-    data class BiometricUnlockFailure(val message: String? = null) : PasscodeAction
+    data class ExternalUnlockFailure(val message: String? = null) : PasscodeAction
 
-    /** Signals that the user is not registered for biometrics. */
-    object BiometricUserNotRegistered : PasscodeAction
+    /** Signals that the user is not registered for external authentication. */
+    object ExternalAuthNotAvailable : PasscodeAction
 
-    /** Initiates the flow to disable biometric authentication (requires passcode verification). */
-    object DisableBiometrics : PasscodeAction
+    /** Initiates the flow to disable external authentication (requires passcode verification). */
+    object DisableExternalAuth : PasscodeAction
 
     /**
-     * Saves biometric registration data.
+     * Saves external authentication registration data.
      * @property registrationData The opaque data string to save.
      */
-    data class SaveBiometricRegistration(val registrationData: String) : PasscodeAction
+    data class SaveExternalRegistration(val registrationData: String) : PasscodeAction
 
-    /** Deletes stored biometric registration data. */
-    object DeleteBiometricRegistration : PasscodeAction
+    /** Deletes stored external authentication registration data. */
+    object DeleteExternalRegistration : PasscodeAction
 }
 
 /**
@@ -535,6 +536,6 @@ enum class PasscodeStep {
     /** User is verifying their old passcode before changing it. */
     ChangeVerify,
 
-    /** User is verifying their passcode to disable biometrics. */
-    DisableBiometrics,
+    /** User is verifying their passcode to disable external authentication. */
+    DisableExternalAuth,
 }

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeStorageAdapter.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeStorageAdapter.kt
@@ -38,21 +38,42 @@ interface PasscodeStorageAdapter {
     fun deletePasscode()
 
     /**
-     * Saves biometric registration data (e.g. FIDO/WebAuthn credential) to persistent storage.
+yes     * Saves external authentication registration data (e.g. FIDO/WebAuthn credential) to persistent storage.
      *
      * @param registrationData The registration data string to be saved.
      */
+    @Deprecated(
+        message = "Use BiometricStorageAdapter from the biometrics library instead.",
+        replaceWith = ReplaceWith(
+            "BiometricStorageAdapter.saveRegistrationData(registrationData)",
+            "org.mifos.authenticator.biometrics.BiometricStorageAdapter",
+        ),
+    )
     fun saveRegistrationData(registrationData: String)
 
     /**
-     * Loads the stored biometric registration data from persistent storage.
+     * Loads the stored external authentication registration data from persistent storage.
      *
      * @return The loaded registration data, or `null` if none is stored.
      */
+    @Deprecated(
+        message = "Use BiometricStorageAdapter from the biometrics library instead.",
+        replaceWith = ReplaceWith(
+            "BiometricStorageAdapter.loadRegistrationData()",
+            "org.mifos.authenticator.biometrics.BiometricStorageAdapter",
+        ),
+    )
     fun loadRegistrationData(): String?
 
     /**
-     * Deletes the biometric registration data from persistent storage.
+     * Deletes the external authentication registration data from persistent storage.
      */
+    @Deprecated(
+        message = "Use BiometricStorageAdapter from the biometrics library instead.",
+        replaceWith = ReplaceWith(
+            "BiometricStorageAdapter.deleteRegistrationData()",
+            "org.mifos.authenticator.biometrics.BiometricStorageAdapter",
+        ),
+    )
     fun deleteRegistrationData()
 }

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/components/PasscodeHeader.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/components/PasscodeHeader.kt
@@ -63,7 +63,7 @@ fun PasscodeHeader(
         if (it == PasscodeStep.Confirm) zeroOffset else positiveOffset
     }
     val xTransitionHeader3 by transition.animateOffset(label = "Transition Offset Header 3") {
-        if (it == PasscodeStep.ChangeVerify || it == PasscodeStep.DisableBiometrics) zeroOffset else positiveOffset
+        if (it == PasscodeStep.ChangeVerify || it == PasscodeStep.DisableExternalAuth) zeroOffset else positiveOffset
     }
     val alphaHeader1 by transition.animateFloat(label = "Transition Alpha Header 1") {
         if (it == PasscodeStep.Create) 1.0F else 0.0F
@@ -72,7 +72,7 @@ fun PasscodeHeader(
         if (it == PasscodeStep.Confirm) 1.0F else 0.0F
     }
     val alphaHeader3 by transition.animateFloat(label = "Transition Alpha Header 3") {
-        if (it == PasscodeStep.ChangeVerify || it == PasscodeStep.DisableBiometrics) 1.0F else 0.0F
+        if (it == PasscodeStep.ChangeVerify || it == PasscodeStep.DisableExternalAuth) 1.0F else 0.0F
     }
     val scaleHeader1 by transition.animateFloat(label = "Transition Scale Header 1") {
         if (it == PasscodeStep.Create) 1.0F else 0.5F
@@ -81,7 +81,7 @@ fun PasscodeHeader(
         if (it == PasscodeStep.Confirm) 1.0F else 0.5F
     }
     val scaleHeader3 by transition.animateFloat(label = "Transition Scale Header 3") {
-        if (it == PasscodeStep.ChangeVerify || it == PasscodeStep.DisableBiometrics) 1.0F else 0.5F
+        if (it == PasscodeStep.ChangeVerify || it == PasscodeStep.DisableExternalAuth) 1.0F else 0.5F
     }
 
     Box(
@@ -119,7 +119,7 @@ fun PasscodeHeader(
                         style = textStyle,
                     )
                 }
-                PasscodeStep.ChangeVerify, PasscodeStep.DisableBiometrics -> {
+                PasscodeStep.ChangeVerify, PasscodeStep.DisableExternalAuth -> {
                     Text(
                         modifier = Modifier
                             .offset(x = xTransitionHeader3.x.dp)

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/components/PasscodeKeys.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/components/PasscodeKeys.kt
@@ -63,7 +63,7 @@ fun PasscodeKeys(
     keyElevation: CardElevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
     keyContainerColor: Color = Color.White,
     keySize: Dp = 60.dp,
-    biometricButton: @Composable ((Modifier) -> Unit)? = null,
+    externalAuthButton: @Composable ((Modifier) -> Unit)? = null,
 ) {
     val onEnterKeyClick = { keyTitle: String ->
         enterKey(keyTitle)
@@ -145,12 +145,12 @@ fun PasscodeKeys(
             )
         }
 
-        if (biometricButton != null) {
+        if (externalAuthButton != null) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.Center,
             ) {
-                biometricButton(Modifier.padding(2.dp))
+                externalAuthButton(Modifier.padding(2.dp))
             }
         }
     }

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/components/SystemAuthConfirmDialog.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/components/SystemAuthConfirmDialog.kt
@@ -34,8 +34,8 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import mifos_authenticator.mifos_authenticator_passcode.generated.resources.Res
-import mifos_authenticator.mifos_authenticator_passcode.generated.resources.enable_biometric_dialog_description
-import mifos_authenticator.mifos_authenticator_passcode.generated.resources.enable_biometric_dialog_title
+import mifos_authenticator.mifos_authenticator_passcode.generated.resources.enable_external_auth_dialog_description
+import mifos_authenticator.mifos_authenticator_passcode.generated.resources.enable_external_auth_dialog_title
 import mifos_authenticator.mifos_authenticator_passcode.generated.resources.no
 import mifos_authenticator.mifos_authenticator_passcode.generated.resources.yes
 import org.jetbrains.compose.resources.stringResource
@@ -70,7 +70,7 @@ fun SystemAuthSetupConfirmDialog(
                 Spacer(modifier = Modifier.height(20.dp))
 
                 Text(
-                    text = stringResource(resource = Res.string.enable_biometric_dialog_title),
+                    text = stringResource(resource = Res.string.enable_external_auth_dialog_title),
                     modifier = Modifier
                         .padding(8.dp),
                     style = titleTextStyle,
@@ -79,7 +79,7 @@ fun SystemAuthSetupConfirmDialog(
                 Spacer(modifier = Modifier.height(4.dp))
 
                 Text(
-                    text = stringResource(resource = Res.string.enable_biometric_dialog_description),
+                    text = stringResource(resource = Res.string.enable_external_auth_dialog_description),
                     modifier = Modifier
                         .padding(8.dp),
                     style = descriptionTextStyle,

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/screen/PasscodeScreen.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/screen/PasscodeScreen.kt
@@ -73,8 +73,8 @@ import org.mifos.authenticator.passcode.utility.ShakeAnimation.performShakeAnima
  * @param onPasscodeCreation Lambda to be invoked when a new passcode is successfully created.
  * @param onPasscodeChanged Lambda to be invoked when the passcode is successfully changed.
  * @param onPasscodeRejected Lambda to be invoked when an entered passcode (for unlock or change verification) is incorrect.
- * @param onDisableBiometrics Lambda to be invoked when biometrics are successfully disabled.
- * @param onBiometricError Lambda to be invoked when a biometric authentication error occurs.
+ * @param onDisableExternalAuth Lambda to be invoked when external authentication is successfully disabled.
+ * @param onExternalAuthError Lambda to be invoked when an external authentication error occurs.
  * @param modifier Optional [Modifier] for the screen's root layout.
  * @param appearanceConfig Configuration for the overall visual appearance of the screen.
  * @param logoConfig Configuration for the logo displayed on the screen.
@@ -83,7 +83,7 @@ import org.mifos.authenticator.passcode.utility.ShakeAnimation.performShakeAnima
  * @param buttonConfig Configuration for action buttons like "Skip" and "Forgot".
  * @param switchConfig Configuration for the passcode length switch.
  * @param dialogConfig Configuration for the "Passcode Mismatched" dialog.
- * @param biometricButton Optional composable to display a biometric authentication button.
+ * @param externalAuthButton Optional composable to display an external authentication button (e.g. biometrics).
  */
 @Composable
 fun PasscodeScreen(
@@ -93,8 +93,8 @@ fun PasscodeScreen(
     onPasscodeCreation: () -> Unit,
     onPasscodeChanged: () -> Unit = {},
     onPasscodeRejected: () -> Unit = {},
-    onDisableBiometrics: () -> Unit = {},
-    onBiometricError: (String?) -> Unit = {},
+    onDisableExternalAuth: () -> Unit = {},
+    onExternalAuthError: (String?) -> Unit = {},
     modifier: Modifier = Modifier,
     appearanceConfig: PasscodeAppearanceConfig = PasscodeAppearanceConfig(),
     logoConfig: PasscodeLogoConfig = PasscodeLogoConfig(),
@@ -103,7 +103,7 @@ fun PasscodeScreen(
     buttonConfig: PasscodeButtonConfig = PasscodeButtonConfig(),
     switchConfig: PasscodeSwitchConfig = PasscodeSwitchConfig(),
     dialogConfig: PasscodeDialogConfig = PasscodeDialogConfig(),
-    biometricButton: @Composable ((Modifier) -> Unit)? = null,
+    externalAuthButton: @Composable ((Modifier) -> Unit)? = null,
 ) {
     val effectiveLogoConfig = logoConfig.copy(
         logoPainter = logoConfig.logoPainter ?: painterResource(resource = Res.drawable.mifos_logo),
@@ -144,8 +144,8 @@ fun PasscodeScreen(
                 PasscodeEvent.OnPasscodeChanged -> {
                     onPasscodeChanged()
                 }
-                PasscodeEvent.OnDisableBiometricsSuccess -> {
-                    onDisableBiometrics()
+                PasscodeEvent.OnDisableExternalAuthSuccess -> {
+                    onDisableExternalAuth()
                 }
                 PasscodeEvent.OnRejectEnteredPasscode -> {
                     passcodeRejectedDialogVisible = true
@@ -159,12 +159,12 @@ fun PasscodeScreen(
                 PasscodeEvent.OnPasscodeDeletion -> {
                     onForgotButton()
                 }
-                is PasscodeEvent.OnBiometricUnlockFailure -> {
+                is PasscodeEvent.OnExternalUnlockFailure -> {
                     performShakeAnimation(xShake)
-                    onBiometricError(it.message)
+                    onExternalAuthError(it.message)
                 }
-                PasscodeEvent.OnBiometricUserNotRegistered -> {
-                    onBiometricError("Biometrics not enabled or invalid biometrics registered.")
+                PasscodeEvent.OnExternalAuthNotAvailable -> {
+                    onExternalAuthError("External authentication not enabled or not registered.")
                     performShakeAnimation(xShake)
                 }
             }
@@ -268,7 +268,7 @@ fun PasscodeScreen(
                 keyElevation = effectiveKeyConfig.keyElevation!!,
                 keyContainerColor = effectiveKeyConfig.keyContainerColor,
                 keySize = effectiveKeyConfig.keySize,
-                biometricButton = if (state.passcodeStep == PasscodeStep.Enter && state.isBiometricEnabled) biometricButton else null,
+                externalAuthButton = if (state.passcodeStep == PasscodeStep.Enter && state.isExternalAuthEnabled) externalAuthButton else null,
             )
             Spacer(modifier = Modifier.height(8.dp))
 


### PR DESCRIPTION
### Summary

- Renamed all biometric-specific APIs in the passcode library to generic "external auth" names (`BiometricUnlockSuccess` -> `ExternalUnlockSuccess`, `isBiometricEnabled` -> `isExternalAuthEnabled`, `DisableBiometrics` -> `DisableExternalAuth`, etc.)
- Removed registration data storage responsibility from `PasscodeManager` — it now only tracks `isExternalAuthEnabled` state. Persistence is the caller's responsibility.
- Added `isExternalAuthEnabled` parameter to `PasscodeManager.initialize()` so callers pass the state from their own storage.
- Created `BiometricStorageAdapter` interface in the biometrics library for registration data persistence.
- Deprecated `saveRegistrationData`/`loadRegistrationData`/`deleteRegistrationData` on `PasscodeStorageAdapter` with `@Deprecated` pointing to `BiometricStorageAdapter`.
- Updated sample app to use `BiometricStorageAdapter` for all registration data operations (save, load, delete on disable/logout/forgot).

### Breaking Changes

- `PasscodeScreen` parameters renamed: `onDisableBiometrics` -> `onDisableExternalAuth`, `onBiometricError` -> `onExternalAuthError`, `biometricButton` -> `externalAuthButton`
- `PasscodeAction`, `PasscodeEvent`, `PasscodeStep`, `PasscodeState` members renamed from `Biometric*` to `External*`
- `PasscodeManager.initialize()` now takes `isExternalAuthEnabled: Boolean` parameter (defaults to `false`)
