### PR TITLE
 Simplify PasscodeManager API and decouple passcode/biometrics libraries

### DIFF
--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/BiometricStorageAdapterImpl.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/BiometricStorageAdapterImpl.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
+ */
+package cmp.sample.shared
+
+import com.russhwolf.settings.Settings
+import org.mifos.authenticator.biometrics.BiometricStorageAdapter
+
+private const val REGISTRATION_DATA_KEY = "org.mifos.authenticator.registration_data"
+
+class BiometricStorageAdapterImpl(
+    private val settings: Settings,
+) : BiometricStorageAdapter {
+    override fun saveRegistrationData(registrationData: String) {
+        settings.putString(REGISTRATION_DATA_KEY, registrationData)
+    }
+
+    override fun loadRegistrationData(): String? {
+        return settings.getStringOrNull(REGISTRATION_DATA_KEY)
+    }
+
+    override fun deleteRegistrationData() {
+        settings.remove(REGISTRATION_DATA_KEY)
+    }
+}

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/PasscodeStorageAdapterImpl.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/PasscodeStorageAdapterImpl.kt
@@ -12,8 +12,7 @@ package cmp.sample.shared
 import com.russhwolf.settings.Settings
 import org.mifos.authenticator.passcode.PasscodeStorageAdapter
 
-const val PASSCODE_KEY = "org.mifos.authenticator.passcode"
-const val REGISTRATION_DATA_KEY = "org.mifos.authenticator.registration_data"
+private const val PASSCODE_KEY = "org.mifos.authenticator.passcode"
 
 class PasscodeStorageAdapterImpl(
     private val settings: Settings,
@@ -30,15 +29,12 @@ class PasscodeStorageAdapterImpl(
         settings.remove(PASSCODE_KEY)
     }
 
-    override fun saveRegistrationData(registrationData: String) {
-        settings.putString(REGISTRATION_DATA_KEY, registrationData)
-    }
+    @Suppress("DEPRECATION")
+    override fun saveRegistrationData(registrationData: String) { }
 
-    override fun loadRegistrationData(): String? {
-        return settings.getStringOrNull(REGISTRATION_DATA_KEY)
-    }
+    @Suppress("DEPRECATION")
+    override fun loadRegistrationData(): String? = null
 
-    override fun deleteRegistrationData() {
-        settings.remove(REGISTRATION_DATA_KEY)
-    }
+    @Suppress("DEPRECATION")
+    override fun deleteRegistrationData() { }
 }

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/di/PasscodeModule.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/di/PasscodeModule.kt
@@ -12,7 +12,6 @@ package cmp.sample.shared.di
 import cmp.sample.shared.BiometricStorageAdapterImpl
 import cmp.sample.shared.PasscodeStorageAdapterImpl
 import com.russhwolf.settings.Settings
-import kotlinx.coroutines.MainScope
 import org.koin.core.context.startKoin
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.KoinAppDeclaration
@@ -28,7 +27,7 @@ val passcodeModule = module {
     single {
         val biometricAdapter = get<BiometricStorageAdapter>()
         val isExternalAuthEnabled = biometricAdapter.loadRegistrationData() != null
-        PasscodeManager(get(), MainScope()).initialize(isExternalAuthEnabled)
+        PasscodeManager(get(), isExternalAuthEnabled)
     }
     single { Settings() }
 }

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/di/PasscodeModule.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/di/PasscodeModule.kt
@@ -9,6 +9,7 @@
  */
 package cmp.sample.shared.di
 
+import cmp.sample.shared.BiometricStorageAdapterImpl
 import cmp.sample.shared.PasscodeStorageAdapterImpl
 import com.russhwolf.settings.Settings
 import kotlinx.coroutines.MainScope
@@ -17,13 +18,17 @@ import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.KoinAppDeclaration
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.mifos.authenticator.biometrics.BiometricStorageAdapter
 import org.mifos.authenticator.passcode.PasscodeManager
 import org.mifos.authenticator.passcode.PasscodeStorageAdapter
 
 val passcodeModule = module {
     singleOf(::PasscodeStorageAdapterImpl).bind<PasscodeStorageAdapter>()
+    singleOf(::BiometricStorageAdapterImpl).bind<BiometricStorageAdapter>()
     single {
-        PasscodeManager(get(), MainScope()).initialize()
+        val biometricAdapter = get<BiometricStorageAdapter>()
+        val isExternalAuthEnabled = biometricAdapter.loadRegistrationData() != null
+        PasscodeManager(get(), MainScope()).initialize(isExternalAuthEnabled)
     }
     single { Settings() }
 }

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/Route.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/Route.kt
@@ -23,7 +23,4 @@ sealed class Route {
 
     @Serializable
     data object BiometricSetupScreen : Route()
-
-    @Serializable
-    data object SettingsPasscodeScreen : Route()
 }

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
@@ -48,8 +48,8 @@ import org.mifos.authenticator.biometrics.platformAuthenticator.PlatformAuthOpti
 import org.mifos.authenticator.biometrics.platformAuthenticator.PlatformAuthenticatorStatus
 import org.mifos.authenticator.biometrics.platformAuthenticator.RegistrationResult
 import org.mifos.authenticator.biometrics.platformAvailableAuthenticationOption
-import org.mifos.authenticator.passcode.PasscodeAction
 import org.mifos.authenticator.passcode.PasscodeManager
+import org.mifos.authenticator.passcode.PasscodeResult
 import org.mifos.authenticator.passcode.PasscodeStorageAdapter
 import org.mifos.authenticator.passcode.components.PasscodeKey
 import org.mifos.authenticator.passcode.screen.PasscodeScreen
@@ -85,34 +85,36 @@ fun SampleAppNavigation(
         composable<Route.PasscodeScreen> {
             PasscodeScreen(
                 passcodeManager = passcodeManager,
-                onPasscodeConfirm = {
-                    navController.popBackStack()
-                    navController.navigate(Route.HomeScreen) {
-                        popUpTo(0)
+                onResult = { result ->
+
+                    when (result) {
+                        PasscodeResult.Changed -> {
+                            navController.navigate(Route.HomeScreen) {
+                                popUpTo(0)
+                            }
+                        }
+                        PasscodeResult.Created -> {
+                            navController.navigate(Route.BiometricSetupScreen)
+                        }
+                        PasscodeResult.ExternalAuthDisabled -> {
+                            biometricStorageAdapter.deleteRegistrationData()
+                            navController.popBackStack()
+                        }
+                        PasscodeResult.Forgotten -> {
+                            biometricStorageAdapter.deleteRegistrationData()
+                            navController.navigate(Route.LoginScreen) {
+                                popUpTo(0)
+                            }
+                        }
+                        PasscodeResult.Rejected -> {
+                        }
+                        PasscodeResult.Verified -> {
+                            navController.popBackStack()
+                            navController.navigate(Route.HomeScreen) {
+                                popUpTo(0)
+                            }
+                        }
                     }
-                },
-                onForgotButton = {
-                    biometricStorageAdapter.deleteRegistrationData()
-                    navController.navigate(Route.LoginScreen) {
-                        popUpTo(0)
-                    }
-                },
-                onPasscodeCreation = {
-                    navController.navigate(Route.BiometricSetupScreen)
-                },
-                onPasscodeChanged = {
-                    navController.navigate(Route.HomeScreen) {
-                        popUpTo(0)
-                    }
-                },
-                onDisableExternalAuth = {
-                    biometricStorageAdapter.deleteRegistrationData()
-                    navController.popBackStack()
-                },
-                onPasscodeRejected = {},
-                onExternalAuthError = { message ->
-                    dialogBoxType = DialogBoxType.ERROR
-                    dialogMessage = message ?: "Authentication failed"
                 },
                 externalAuthButton = { modifier ->
                     BiometricKey(
@@ -121,6 +123,10 @@ fun SampleAppNavigation(
                         onUserNotRegistered = {
                             dialogBoxType = DialogBoxType.ERROR
                             dialogMessage = "User not registered for biometrics. Please use passcode or re-register in settings."
+                        },
+                        onAuthenticationError = { message ->
+                            dialogBoxType = DialogBoxType.ERROR
+                            dialogMessage = message
                         },
                     )
                 },
@@ -139,6 +145,7 @@ fun SampleAppNavigation(
         composable<Route.BiometricSetupScreen> {
             BiometricSetupScreen(
                 onBiometricsRegistrationSuccess = {
+                    passcodeManager.setExternalAuthEnabled(true)
                     navController.navigate(Route.HomeScreen) {
                         popUpTo(0)
                     }
@@ -198,6 +205,7 @@ fun BiometricKey(
     modifier: Modifier,
     passcodeManager: PasscodeManager,
     onUserNotRegistered: () -> Unit,
+    onAuthenticationError: (String) -> Unit,
     biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
 ) {
     val platformAuthenticationProvider = platformAuthenticationProvider.current
@@ -227,16 +235,14 @@ fun BiometricKey(
                     )
                     when (result) {
                         is AuthenticationResult.Success -> {
-                            passcodeManager.trySendAction(PasscodeAction.ExternalUnlockSuccess)
+                            passcodeManager.notifyExternalAuthSuccess()
                         }
                         is AuthenticationResult.Error -> {
-                            passcodeManager.trySendAction(
-                                PasscodeAction.ExternalUnlockFailure(
-                                    result.message,
-                                ),
-                            )
+                            onAuthenticationError(result.message)
                         }
                         is AuthenticationResult.UserNotRegistered -> {
+                            passcodeManager.setExternalAuthEnabled(false)
+                            biometricStorageAdapter.deleteRegistrationData()
                             onUserNotRegistered()
                         }
 
@@ -304,7 +310,7 @@ fun HomeScreen(
         Button(
             onClick = {
                 biometricStorageAdapter.deleteRegistrationData()
-                passcodeManager.trySendAction(PasscodeAction.LogOutErasePasscode)
+                passcodeManager.logOut()
                 onLogoutClick()
             },
         ) {
@@ -318,7 +324,7 @@ fun HomeScreen(
 
             Button(
                 onClick = {
-                    passcodeManager.trySendAction(PasscodeAction.ChangePasscode)
+                    passcodeManager.changePasscode()
                     navigateToPasscodeScreen()
                 },
             ) {
@@ -333,7 +339,7 @@ fun HomeScreen(
                 onClick = {
                     if (state.isExternalAuthEnabled) {
                         // Disabling: should require passcode verification
-                        passcodeManager.trySendAction(PasscodeAction.DisableExternalAuth)
+                        passcodeManager.disableExternalAuth()
                         navigateToPasscodeScreen()
                     } else {
                         scope.launch {
@@ -345,11 +351,10 @@ fun HomeScreen(
                             when (result) {
                                 is RegistrationResult.Success -> {
                                     biometricStorageAdapter.saveRegistrationData(result.message)
-                                    passcodeManager.trySendAction(PasscodeAction.SaveExternalRegistration(result.message))
+                                    passcodeManager.setExternalAuthEnabled(true)
                                     onEnableBiometricsSuccess()
                                 }
                                 RegistrationResult.PlatformAuthenticatorNotSet -> {
-                                    passcodeManager.trySendAction(PasscodeAction.ExternalAuthNotAvailable)
                                     onBiometricsEnableError("Biometrics are not set up on this device. Please enable fingerprint or face unlock in your device settings, then try again.")
                                 }
                                 RegistrationResult.PlatformAuthenticatorNotAvailable -> {

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
@@ -41,6 +41,7 @@ import cmp.sample.shared.ui.components.DialogBoxType
 import cmp.sample.shared.ui.components.MessageDialogBox
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import org.mifos.authenticator.biometrics.BiometricStorageAdapter
 import org.mifos.authenticator.biometrics.platformAuthenticationProvider
 import org.mifos.authenticator.biometrics.platformAuthenticator.AuthenticationResult
 import org.mifos.authenticator.biometrics.platformAuthenticator.PlatformAuthOptions
@@ -56,6 +57,7 @@ import org.mifos.authenticator.passcode.screen.PasscodeScreen
 @Composable
 fun SampleAppNavigation(
     passcodeStorageAdapter: PasscodeStorageAdapter = koinInject(),
+    biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
 ) {
     val navController = rememberNavController()
 
@@ -90,6 +92,7 @@ fun SampleAppNavigation(
                     }
                 },
                 onForgotButton = {
+                    biometricStorageAdapter.deleteRegistrationData()
                     navController.navigate(Route.LoginScreen) {
                         popUpTo(0)
                     }
@@ -102,15 +105,16 @@ fun SampleAppNavigation(
                         popUpTo(0)
                     }
                 },
-                onDisableBiometrics = {
+                onDisableExternalAuth = {
+                    biometricStorageAdapter.deleteRegistrationData()
                     navController.popBackStack()
                 },
                 onPasscodeRejected = {},
-                onBiometricError = { message ->
+                onExternalAuthError = { message ->
                     dialogBoxType = DialogBoxType.ERROR
-                    dialogMessage = message ?: "Biometric authentication failed"
+                    dialogMessage = message ?: "Authentication failed"
                 },
-                biometricButton = { modifier ->
+                externalAuthButton = { modifier ->
                     BiometricKey(
                         modifier = modifier,
                         passcodeManager = passcodeManager,
@@ -194,7 +198,7 @@ fun BiometricKey(
     modifier: Modifier,
     passcodeManager: PasscodeManager,
     onUserNotRegistered: () -> Unit,
-    passcodeStorageAdapter: PasscodeStorageAdapter = koinInject(),
+    biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
 ) {
     val platformAuthenticationProvider = platformAuthenticationProvider.current
     val platformAvailableAuthenticationOption = platformAvailableAuthenticationOption.current
@@ -219,15 +223,15 @@ fun BiometricKey(
                 scope.launch {
                     val result = platformAuthenticationProvider.onAuthenticatorClick(
                         "Unlock with Biometrics",
-                        passcodeStorageAdapter.loadRegistrationData() ?: "",
+                        biometricStorageAdapter.loadRegistrationData() ?: "",
                     )
                     when (result) {
                         is AuthenticationResult.Success -> {
-                            passcodeManager.trySendAction(PasscodeAction.BiometricUnlockSuccess)
+                            passcodeManager.trySendAction(PasscodeAction.ExternalUnlockSuccess)
                         }
                         is AuthenticationResult.Error -> {
                             passcodeManager.trySendAction(
-                                PasscodeAction.BiometricUnlockFailure(
+                                PasscodeAction.ExternalUnlockFailure(
                                     result.message,
                                 ),
                             )
@@ -279,6 +283,7 @@ fun HomeScreen(
     onEnableBiometricsSuccess: () -> Unit,
     onBiometricsEnableError: (String) -> Unit,
     passcodeManager: PasscodeManager = koinInject<PasscodeManager>(),
+    biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
 ) {
     val state by passcodeManager.state.collectAsState()
     val platformAuthenticationProvider = platformAuthenticationProvider.current
@@ -298,6 +303,7 @@ fun HomeScreen(
 
         Button(
             onClick = {
+                biometricStorageAdapter.deleteRegistrationData()
                 passcodeManager.trySendAction(PasscodeAction.LogOutErasePasscode)
                 onLogoutClick()
             },
@@ -325,9 +331,9 @@ fun HomeScreen(
 
             Button(
                 onClick = {
-                    if (state.isBiometricEnabled) {
+                    if (state.isExternalAuthEnabled) {
                         // Disabling: should require passcode verification
-                        passcodeManager.trySendAction(PasscodeAction.DisableBiometrics)
+                        passcodeManager.trySendAction(PasscodeAction.DisableExternalAuth)
                         navigateToPasscodeScreen()
                     } else {
                         scope.launch {
@@ -338,11 +344,12 @@ fun HomeScreen(
                             )
                             when (result) {
                                 is RegistrationResult.Success -> {
-                                    passcodeManager.trySendAction(PasscodeAction.SaveBiometricRegistration(result.message))
+                                    biometricStorageAdapter.saveRegistrationData(result.message)
+                                    passcodeManager.trySendAction(PasscodeAction.SaveExternalRegistration(result.message))
                                     onEnableBiometricsSuccess()
                                 }
                                 RegistrationResult.PlatformAuthenticatorNotSet -> {
-                                    passcodeManager.trySendAction(PasscodeAction.BiometricUserNotRegistered)
+                                    passcodeManager.trySendAction(PasscodeAction.ExternalAuthNotAvailable)
                                     onBiometricsEnableError("Biometrics are not set up on this device. Please enable fingerprint or face unlock in your device settings, then try again.")
                                 }
                                 RegistrationResult.PlatformAuthenticatorNotAvailable -> {
@@ -358,7 +365,7 @@ fun HomeScreen(
                 },
             ) {
                 Text(
-                    if (state.isBiometricEnabled) "Disable Biometrics" else "Enable Biometrics",
+                    if (state.isExternalAuthEnabled) "Disable Biometrics" else "Enable Biometrics",
                 )
             }
         }

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
@@ -9,49 +9,26 @@
  */
 package cmp.sample.shared.navigation
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Face
-import androidx.compose.material.icons.filled.Fingerprint
-import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import cmp.sample.shared.platformAuthentication.BiometricKey
 import cmp.sample.shared.platformAuthentication.BiometricSetupScreen
+import cmp.sample.shared.screens.HomeScreen
+import cmp.sample.shared.screens.LoginScreen
 import cmp.sample.shared.ui.components.DialogBoxType
 import cmp.sample.shared.ui.components.MessageDialogBox
-import kotlinx.coroutines.launch
+import co.touchlab.kermit.Logger
 import org.koin.compose.koinInject
 import org.mifos.authenticator.biometrics.BiometricStorageAdapter
-import org.mifos.authenticator.biometrics.platformAuthenticationProvider
-import org.mifos.authenticator.biometrics.platformAuthenticator.AuthenticationResult
-import org.mifos.authenticator.biometrics.platformAuthenticator.PlatformAuthOptions
-import org.mifos.authenticator.biometrics.platformAuthenticator.PlatformAuthenticatorStatus
-import org.mifos.authenticator.biometrics.platformAuthenticator.RegistrationResult
-import org.mifos.authenticator.biometrics.platformAvailableAuthenticationOption
 import org.mifos.authenticator.passcode.PasscodeManager
 import org.mifos.authenticator.passcode.PasscodeResult
 import org.mifos.authenticator.passcode.PasscodeStorageAdapter
-import org.mifos.authenticator.passcode.components.PasscodeKey
 import org.mifos.authenticator.passcode.screen.PasscodeScreen
 
 @Composable
@@ -60,21 +37,16 @@ fun SampleAppNavigation(
     biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
 ) {
     val navController = rememberNavController()
+    val passcodeManager = koinInject<PasscodeManager>()
 
     val isUsingPasscode = !passcodeStorageAdapter.loadPasscode().isNullOrBlank()
 
     var dialogBoxType by remember { mutableStateOf(DialogBoxType.None) }
     var dialogMessage by remember { mutableStateOf("") }
 
-    val passcodeManager = koinInject<PasscodeManager>()
-
     val startDestination by remember {
         mutableStateOf(
-            if (isUsingPasscode) {
-                Route.PasscodeScreen
-            } else {
-                Route.LoginScreen
-            },
+            if (isUsingPasscode) Route.PasscodeScreen else Route.LoginScreen,
         )
     }
 
@@ -86,34 +58,27 @@ fun SampleAppNavigation(
             PasscodeScreen(
                 passcodeManager = passcodeManager,
                 onResult = { result ->
-
                     when (result) {
-                        PasscodeResult.Changed -> {
-                            navController.navigate(Route.HomeScreen) {
-                                popUpTo(0)
-                            }
+                        PasscodeResult.Verified -> {
+                            navController.popBackStack()
+                            navController.navigate(Route.HomeScreen) { popUpTo(0) }
                         }
                         PasscodeResult.Created -> {
                             navController.navigate(Route.BiometricSetupScreen)
+                        }
+                        PasscodeResult.Changed -> {
+                            navController.navigate(Route.HomeScreen) { popUpTo(0) }
+                        }
+                        PasscodeResult.Forgotten -> {
+                            Logger.e { "Forget passcode is triggered" }
+                            biometricStorageAdapter.deleteRegistrationData()
+                            navController.navigate(Route.LoginScreen) { popUpTo(0) }
                         }
                         PasscodeResult.ExternalAuthDisabled -> {
                             biometricStorageAdapter.deleteRegistrationData()
                             navController.popBackStack()
                         }
-                        PasscodeResult.Forgotten -> {
-                            biometricStorageAdapter.deleteRegistrationData()
-                            navController.navigate(Route.LoginScreen) {
-                                popUpTo(0)
-                            }
-                        }
-                        PasscodeResult.Rejected -> {
-                        }
-                        PasscodeResult.Verified -> {
-                            navController.popBackStack()
-                            navController.navigate(Route.HomeScreen) {
-                                popUpTo(0)
-                            }
-                        }
+                        PasscodeResult.Rejected -> { }
                     }
                 },
                 externalAuthButton = { modifier ->
@@ -122,7 +87,8 @@ fun SampleAppNavigation(
                         passcodeManager = passcodeManager,
                         onUserNotRegistered = {
                             dialogBoxType = DialogBoxType.ERROR
-                            dialogMessage = "User not registered for biometrics. Please use passcode or re-register in settings."
+                            dialogMessage = "User not registered for biometrics. " +
+                                "Please use passcode or re-register in settings."
                         },
                         onAuthenticationError = { message ->
                             dialogBoxType = DialogBoxType.ERROR
@@ -134,9 +100,7 @@ fun SampleAppNavigation(
 
             if (dialogBoxType != DialogBoxType.None) {
                 MessageDialogBox(
-                    onDismissRequest = {
-                        dialogBoxType = DialogBoxType.None
-                    },
+                    onDismissRequest = { dialogBoxType = DialogBoxType.None },
                     dialogMessage = dialogMessage,
                 )
             }
@@ -146,14 +110,10 @@ fun SampleAppNavigation(
             BiometricSetupScreen(
                 onBiometricsRegistrationSuccess = {
                     passcodeManager.setExternalAuthEnabled(true)
-                    navController.navigate(Route.HomeScreen) {
-                        popUpTo(0)
-                    }
+                    navController.navigate(Route.HomeScreen) { popUpTo(0) }
                 },
                 onSkipBiometricSetup = {
-                    navController.navigate(Route.HomeScreen) {
-                        popUpTo(0)
-                    }
+                    navController.navigate(Route.HomeScreen) { popUpTo(0) }
                 },
                 onError = { message ->
                     dialogBoxType = DialogBoxType.ERROR
@@ -170,209 +130,28 @@ fun SampleAppNavigation(
         }
 
         composable<Route.LoginScreen> {
-            LoginScreen {
-                navController.navigate(Route.PasscodeScreen)
-            }
+            LoginScreen(
+                onSetupAppLock = { navController.navigate(Route.PasscodeScreen) },
+            )
         }
 
         composable<Route.HomeScreen> {
             HomeScreen(
                 usingPasscode = !passcodeStorageAdapter.loadPasscode().isNullOrBlank(),
                 onLogoutClick = {
-                    navController.navigate(Route.LoginScreen) {
-                        popUpTo(0)
-                    }
+                    navController.navigate(Route.LoginScreen) { popUpTo(0) }
                 },
                 navigateToPasscodeScreen = {
                     navController.navigate(Route.PasscodeScreen)
                 },
                 onEnableBiometricsSuccess = {
-                    navController.navigate(Route.PasscodeScreen) {
-                        popUpTo(0)
-                    }
+                    navController.navigate(Route.PasscodeScreen) { popUpTo(0) }
                 },
                 onBiometricsEnableError = { message ->
                     dialogBoxType = DialogBoxType.ERROR
                     dialogMessage = message
                 },
             )
-        }
-    }
-}
-
-@Composable
-fun BiometricKey(
-    modifier: Modifier,
-    passcodeManager: PasscodeManager,
-    onUserNotRegistered: () -> Unit,
-    onAuthenticationError: (String) -> Unit,
-    biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
-) {
-    val platformAuthenticationProvider = platformAuthenticationProvider.current
-    val platformAvailableAuthenticationOption = platformAvailableAuthenticationOption.current
-    val platformAuthOptions by platformAvailableAuthenticationOption.currentAuthOption.collectAsState()
-    val authenticatorStatus by platformAuthenticationProvider.authenticatorStatus.collectAsState()
-    val scope = rememberCoroutineScope()
-
-    val isBiometricAvailable = authenticatorStatus.contains(PlatformAuthenticatorStatus.BIOMETRICS_SET) ||
-        authenticatorStatus.contains(PlatformAuthenticatorStatus.DEVICE_CREDENTIAL_SET)
-
-    if (isBiometricAvailable) {
-        val icon: ImageVector = when {
-            platformAuthOptions.contains(PlatformAuthOptions.Fingerprint) -> Icons.Default.Fingerprint
-            platformAuthOptions.contains(PlatformAuthOptions.FaceId) -> Icons.Default.Face
-            else -> Icons.Default.Lock
-        }
-
-        PasscodeKey(
-            modifier = modifier,
-            keyIcon = icon,
-            onClick = {
-                scope.launch {
-                    val result = platformAuthenticationProvider.onAuthenticatorClick(
-                        "Unlock with Biometrics",
-                        biometricStorageAdapter.loadRegistrationData() ?: "",
-                    )
-                    when (result) {
-                        is AuthenticationResult.Success -> {
-                            passcodeManager.notifyExternalAuthSuccess()
-                        }
-                        is AuthenticationResult.Error -> {
-                            onAuthenticationError(result.message)
-                        }
-                        is AuthenticationResult.UserNotRegistered -> {
-                            passcodeManager.setExternalAuthEnabled(false)
-                            biometricStorageAdapter.deleteRegistrationData()
-                            onUserNotRegistered()
-                        }
-
-                        AuthenticationResult.UserCancelled -> { /* User dismissed prompt, do nothing */ }
-                    }
-                }
-            },
-        )
-    }
-}
-
-@Composable
-fun LoginScreen(
-    onLogoutClick: () -> Unit,
-) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(
-            "Login Screen",
-            fontSize = 48.sp,
-            fontWeight = FontWeight.ExtraBold,
-        )
-        Spacer(modifier = Modifier.height(100.dp))
-        Button(
-            onClick = {
-                onLogoutClick()
-            },
-        ) {
-            Text(
-                "Setup App Lock",
-            )
-        }
-    }
-}
-
-@Composable
-fun HomeScreen(
-    usingPasscode: Boolean,
-    onLogoutClick: () -> Unit,
-    navigateToPasscodeScreen: () -> Unit,
-    onEnableBiometricsSuccess: () -> Unit,
-    onBiometricsEnableError: (String) -> Unit,
-    passcodeManager: PasscodeManager = koinInject<PasscodeManager>(),
-    biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
-) {
-    val state by passcodeManager.state.collectAsState()
-    val platformAuthenticationProvider = platformAuthenticationProvider.current
-    val scope = rememberCoroutineScope()
-
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(
-            "Home Screen",
-            fontSize = 48.sp,
-            fontWeight = FontWeight.ExtraBold,
-        )
-        Spacer(modifier = Modifier.height(100.dp))
-
-        Button(
-            onClick = {
-                biometricStorageAdapter.deleteRegistrationData()
-                passcodeManager.logOut()
-                onLogoutClick()
-            },
-        ) {
-            Text(
-                "Log Out",
-            )
-        }
-
-        if (usingPasscode) {
-            Spacer(modifier = Modifier.height(20.dp))
-
-            Button(
-                onClick = {
-                    passcodeManager.changePasscode()
-                    navigateToPasscodeScreen()
-                },
-            ) {
-                Text(
-                    "Change Passcode",
-                )
-            }
-
-            Spacer(modifier = Modifier.height(20.dp))
-
-            Button(
-                onClick = {
-                    if (state.isExternalAuthEnabled) {
-                        // Disabling: should require passcode verification
-                        passcodeManager.disableExternalAuth()
-                        navigateToPasscodeScreen()
-                    } else {
-                        scope.launch {
-                            val result = platformAuthenticationProvider.registerUser(
-                                "mifosUser",
-                                "mifos@mifos.org",
-                                "Mifos User",
-                            )
-                            when (result) {
-                                is RegistrationResult.Success -> {
-                                    biometricStorageAdapter.saveRegistrationData(result.message)
-                                    passcodeManager.setExternalAuthEnabled(true)
-                                    onEnableBiometricsSuccess()
-                                }
-                                RegistrationResult.PlatformAuthenticatorNotSet -> {
-                                    onBiometricsEnableError("Biometrics are not set up on this device. Please enable fingerprint or face unlock in your device settings, then try again.")
-                                }
-                                RegistrationResult.PlatformAuthenticatorNotAvailable -> {
-                                    onBiometricsEnableError("Biometrics not available on this device")
-                                }
-                                is RegistrationResult.Error -> {
-                                    onBiometricsEnableError(result.message)
-                                }
-                                RegistrationResult.UserCancelled -> { /* User dismissed prompt, do nothing */ }
-                            }
-                        }
-                    }
-                },
-            ) {
-                Text(
-                    if (state.isExternalAuthEnabled) "Disable Biometrics" else "Enable Biometrics",
-                )
-            }
         }
     }
 }

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/BiometricKey.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/BiometricKey.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
+ */
+package cmp.sample.shared.platformAuthentication
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.Fingerprint
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+import org.mifos.authenticator.biometrics.BiometricStorageAdapter
+import org.mifos.authenticator.biometrics.platformAuthenticationProvider
+import org.mifos.authenticator.biometrics.platformAuthenticator.AuthenticationResult
+import org.mifos.authenticator.biometrics.platformAuthenticator.PlatformAuthOptions
+import org.mifos.authenticator.biometrics.platformAuthenticator.PlatformAuthenticatorStatus
+import org.mifos.authenticator.biometrics.platformAvailableAuthenticationOption
+import org.mifos.authenticator.passcode.PasscodeManager
+import org.mifos.authenticator.passcode.components.PasscodeKey
+
+@Composable
+fun BiometricKey(
+    modifier: Modifier,
+    passcodeManager: PasscodeManager,
+    onUserNotRegistered: () -> Unit,
+    onAuthenticationError: (String) -> Unit,
+    biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
+) {
+    val platformAuthenticationProvider = platformAuthenticationProvider.current
+    val platformAvailableAuthenticationOption = platformAvailableAuthenticationOption.current
+    val platformAuthOptions by platformAvailableAuthenticationOption.currentAuthOption.collectAsState()
+    val authenticatorStatus by platformAuthenticationProvider.authenticatorStatus.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    val isBiometricAvailable = authenticatorStatus.contains(PlatformAuthenticatorStatus.BIOMETRICS_SET) ||
+        authenticatorStatus.contains(PlatformAuthenticatorStatus.DEVICE_CREDENTIAL_SET)
+
+    if (isBiometricAvailable) {
+        val icon: ImageVector = when {
+            platformAuthOptions.contains(PlatformAuthOptions.Fingerprint) -> Icons.Default.Fingerprint
+            platformAuthOptions.contains(PlatformAuthOptions.FaceId) -> Icons.Default.Face
+            else -> Icons.Default.Lock
+        }
+
+        PasscodeKey(
+            modifier = modifier,
+            keyIcon = icon,
+            onClick = {
+                scope.launch {
+                    val result = platformAuthenticationProvider.onAuthenticatorClick(
+                        "Unlock with Biometrics",
+                        biometricStorageAdapter.loadRegistrationData() ?: "",
+                    )
+                    when (result) {
+                        is AuthenticationResult.Success -> {
+                            passcodeManager.notifyExternalAuthSuccess()
+                        }
+                        is AuthenticationResult.Error -> {
+                            onAuthenticationError(result.message)
+                        }
+                        is AuthenticationResult.UserNotRegistered -> {
+                            passcodeManager.setExternalAuthEnabled(false)
+                            biometricStorageAdapter.deleteRegistrationData()
+                            onUserNotRegistered()
+                        }
+                        AuthenticationResult.UserCancelled -> { }
+                    }
+                }
+            },
+        )
+    }
+}

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/BiometricSetupScreen.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/BiometricSetupScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.sp
 import cmp.sample.shared.theme.blueTint
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import org.mifos.authenticator.biometrics.BiometricStorageAdapter
 import org.mifos.authenticator.biometrics.platformAuthenticationProvider
 import org.mifos.authenticator.biometrics.platformAuthenticator.RegistrationResult
 import org.mifos.authenticator.passcode.PasscodeAction
@@ -49,6 +50,7 @@ fun BiometricSetupScreen(
     onSkipBiometricSetup: () -> Unit,
     onError: (String) -> Unit,
     passcodeManager: PasscodeManager = koinInject(),
+    biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
 ) {
     val platformAuthenticationProvider = platformAuthenticationProvider.current
     val scope = rememberCoroutineScope()
@@ -102,11 +104,12 @@ fun BiometricSetupScreen(
                         )
                         when (result) {
                             is RegistrationResult.Success -> {
-                                passcodeManager.trySendAction(PasscodeAction.SaveBiometricRegistration(result.message))
+                                biometricStorageAdapter.saveRegistrationData(result.message)
+                                passcodeManager.trySendAction(PasscodeAction.SaveExternalRegistration(result.message))
                                 onBiometricsRegistrationSuccess()
                             }
                             RegistrationResult.PlatformAuthenticatorNotSet -> {
-                                passcodeManager.trySendAction(PasscodeAction.BiometricUserNotRegistered)
+                                passcodeManager.trySendAction(PasscodeAction.ExternalAuthNotAvailable)
                                 onError("Biometrics are not set up on this device. Please enable fingerprint or face unlock in your device settings, then try again.")
                             }
                             RegistrationResult.PlatformAuthenticatorNotAvailable -> {

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/BiometricSetupScreen.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/BiometricSetupScreen.kt
@@ -39,8 +39,6 @@ import org.koin.compose.koinInject
 import org.mifos.authenticator.biometrics.BiometricStorageAdapter
 import org.mifos.authenticator.biometrics.platformAuthenticationProvider
 import org.mifos.authenticator.biometrics.platformAuthenticator.RegistrationResult
-import org.mifos.authenticator.passcode.PasscodeAction
-import org.mifos.authenticator.passcode.PasscodeManager
 import org.mifos.authenticator.passcode.components.MifosIcon
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -49,7 +47,6 @@ fun BiometricSetupScreen(
     onBiometricsRegistrationSuccess: () -> Unit,
     onSkipBiometricSetup: () -> Unit,
     onError: (String) -> Unit,
-    passcodeManager: PasscodeManager = koinInject(),
     biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
 ) {
     val platformAuthenticationProvider = platformAuthenticationProvider.current
@@ -105,11 +102,9 @@ fun BiometricSetupScreen(
                         when (result) {
                             is RegistrationResult.Success -> {
                                 biometricStorageAdapter.saveRegistrationData(result.message)
-                                passcodeManager.trySendAction(PasscodeAction.SaveExternalRegistration(result.message))
                                 onBiometricsRegistrationSuccess()
                             }
                             RegistrationResult.PlatformAuthenticatorNotSet -> {
-                                passcodeManager.trySendAction(PasscodeAction.ExternalAuthNotAvailable)
                                 onError("Biometrics are not set up on this device. Please enable fingerprint or face unlock in your device settings, then try again.")
                             }
                             RegistrationResult.PlatformAuthenticatorNotAvailable -> {

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/screens/HomeScreen.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/screens/HomeScreen.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
+ */
+package cmp.sample.shared.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+import org.mifos.authenticator.biometrics.BiometricStorageAdapter
+import org.mifos.authenticator.biometrics.platformAuthenticationProvider
+import org.mifos.authenticator.biometrics.platformAuthenticator.RegistrationResult
+import org.mifos.authenticator.passcode.PasscodeManager
+
+@Composable
+fun HomeScreen(
+    usingPasscode: Boolean,
+    onLogoutClick: () -> Unit,
+    navigateToPasscodeScreen: () -> Unit,
+    onEnableBiometricsSuccess: () -> Unit,
+    onBiometricsEnableError: (String) -> Unit,
+    passcodeManager: PasscodeManager = koinInject<PasscodeManager>(),
+    biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
+) {
+    val state by passcodeManager.state.collectAsState()
+    val platformAuthenticationProvider = platformAuthenticationProvider.current
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            "Home Screen",
+            fontSize = 48.sp,
+            fontWeight = FontWeight.ExtraBold,
+        )
+        Spacer(modifier = Modifier.height(100.dp))
+
+        Button(
+            onClick = {
+                biometricStorageAdapter.deleteRegistrationData()
+                passcodeManager.logOut()
+                onLogoutClick()
+            },
+        ) {
+            Text("Log Out")
+        }
+
+        if (usingPasscode) {
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Button(
+                onClick = {
+                    passcodeManager.changePasscode()
+                    navigateToPasscodeScreen()
+                },
+            ) {
+                Text("Change Passcode")
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Button(
+                onClick = {
+                    if (state.isExternalAuthEnabled) {
+                        passcodeManager.disableExternalAuth()
+                        navigateToPasscodeScreen()
+                    } else {
+                        scope.launch {
+                            val result = platformAuthenticationProvider.registerUser(
+                                "mifosUser",
+                                "mifos@mifos.org",
+                                "Mifos User",
+                            )
+                            when (result) {
+                                is RegistrationResult.Success -> {
+                                    biometricStorageAdapter.saveRegistrationData(result.message)
+                                    passcodeManager.setExternalAuthEnabled(true)
+                                    onEnableBiometricsSuccess()
+                                }
+                                RegistrationResult.PlatformAuthenticatorNotSet -> {
+                                    onBiometricsEnableError(
+                                        "Biometrics are not set up on this device. " +
+                                            "Please enable fingerprint or face unlock in your device settings, then try again.",
+                                    )
+                                }
+                                RegistrationResult.PlatformAuthenticatorNotAvailable -> {
+                                    onBiometricsEnableError("Biometrics not available on this device")
+                                }
+                                is RegistrationResult.Error -> {
+                                    onBiometricsEnableError(result.message)
+                                }
+                                RegistrationResult.UserCancelled -> { }
+                            }
+                        }
+                    }
+                },
+            ) {
+                Text(
+                    if (state.isExternalAuthEnabled) "Disable Biometrics" else "Enable Biometrics",
+                )
+            }
+        }
+    }
+}

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/screens/LoginScreen.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/screens/LoginScreen.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
+ */
+package cmp.sample.shared.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun LoginScreen(
+    onSetupAppLock: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            "Login Screen",
+            fontSize = 48.sp,
+            fontWeight = FontWeight.ExtraBold,
+        )
+        Spacer(modifier = Modifier.height(100.dp))
+        Button(onClick = onSetupAppLock) {
+            Text("Setup App Lock")
+        }
+    }
+}

--- a/mifos-authenticator-biometrics/README.md
+++ b/mifos-authenticator-biometrics/README.md
@@ -4,7 +4,7 @@ This module provides a unified and multiplatform way to handle device-based auth
 
 ## Installation
 
-Add the `io.github.openmf:mifos-authenticator-passcode` dependency to your `build.gradle.kts` file:
+Add the `io.github.openmf:mifos-authenticator-biometrics` dependency to your `build.gradle.kts` file:
 
 ---
 
@@ -56,6 +56,9 @@ viewModelScope.launch(Dispatchers.Main) { // Must be on Main thread for Android
         is RegistrationResult.Error -> {
             showError(result.message)
         }
+        RegistrationResult.UserCancelled -> {
+            // User dismissed the prompt, do nothing
+        }
         RegistrationResult.PlatformAuthenticatorNotSet -> {
             promptUserToSetup()
         }
@@ -82,6 +85,9 @@ viewModelScope.launch(Dispatchers.Main) { // Must be on Main thread for Android
         }
         is AuthenticationResult.Error -> {
             showError(result.message)
+        }
+        AuthenticationResult.UserCancelled -> {
+            // User dismissed the prompt, do nothing
         }
         AuthenticationResult.UserNotRegistered -> {
             // User needs to register again
@@ -170,6 +176,7 @@ Returned by `registerUser()`:
 sealed interface RegistrationResult {
     data class Success(val message: String) : RegistrationResult
     data class Error(val message: String) : RegistrationResult
+    data object UserCancelled : RegistrationResult
     data object PlatformAuthenticatorNotSet : RegistrationResult
     data object PlatformAuthenticatorNotAvailable : RegistrationResult
 }
@@ -185,7 +192,40 @@ Returned by `onAuthenticatorClick()`:
 sealed interface AuthenticationResult {
     data object Success : AuthenticationResult
     data class Error(val message: String) : AuthenticationResult
+    data object UserCancelled : AuthenticationResult
     data object UserNotRegistered : AuthenticationResult
+}
+```
+
+### `BiometricStorageAdapter` (Interface)
+
+Interface for persisting biometric registration data. Implement this to store registration data from `RegistrationResult.Success`:
+
+```kotlin
+interface BiometricStorageAdapter {
+    fun saveRegistrationData(registrationData: String)
+    fun loadRegistrationData(): String?
+    fun deleteRegistrationData()
+}
+```
+
+Example implementation using `multiplatform-settings`:
+
+```kotlin
+class BiometricStorageAdapterImpl(
+    private val settings: Settings,
+) : BiometricStorageAdapter {
+    override fun saveRegistrationData(registrationData: String) {
+        settings.putString("biometric_registration_data", registrationData)
+    }
+
+    override fun loadRegistrationData(): String? {
+        return settings.getStringOrNull("biometric_registration_data")
+    }
+
+    override fun deleteRegistrationData() {
+        settings.remove("biometric_registration_data")
+    }
 }
 ```
 
@@ -303,9 +343,10 @@ class RegistrationViewModel(
             val result = authProvider.registerUser(userID, userEmail, displayName)
             _registrationResult.value = result
 
-            // Save registration data if successful
-            if (result is RegistrationResult.Success) {
-                preferenceStore.saveRegistrationData(result.message)
+            when (result) {
+                is RegistrationResult.Success -> preferenceStore.saveRegistrationData(result.message)
+                RegistrationResult.UserCancelled -> { /* no-op */ }
+                else -> { /* handle error */ }
             }
         }
     }
@@ -340,9 +381,10 @@ class AuthenticationViewModel(
             _authResult.value = result
             _isLoading.value = false
 
-            // Handle user not registered
-            if (result is AuthenticationResult.UserNotRegistered) {
-                clearUserData()
+            when (result) {
+                AuthenticationResult.UserNotRegistered -> clearUserData()
+                AuthenticationResult.UserCancelled -> { /* no-op */ }
+                else -> { /* handle success or error */ }
             }
         }
     }
@@ -427,4 +469,127 @@ class AuthSetupScreen(
 - Check that biometrics are enrolled in iOS Settings
 - Verify app has `NSFaceIDUsageDescription` in Info.plist
 - Ensure device supports Face ID or Touch ID
+
+---
+
+## Using with Passcode Library
+
+If you're using `mifos-authenticator-biometrics` alongside `mifos-authenticator-passcode`, here's how they work together:
+
+### 1. Wrap your app with `PlatformAuthenticatorLocalCompositionProvider`
+
+```kotlin
+@Composable
+fun App() {
+    PlatformAuthenticatorLocalCompositionProvider {
+        MaterialTheme {
+            AppNavigation()
+        }
+    }
+}
+```
+
+### 2. DI Setup
+
+```kotlin
+val appModule = module {
+    single { Settings() }
+    singleOf(::PasscodeStorageAdapterImpl).bind<PasscodeStorageAdapter>()
+    singleOf(::BiometricStorageAdapterImpl).bind<BiometricStorageAdapter>()
+    single {
+        val isExternalAuthEnabled = get<BiometricStorageAdapter>().loadRegistrationData() != null
+        PasscodeManager(get<PasscodeStorageAdapter>(), isExternalAuthEnabled)
+    }
+}
+```
+
+### 3. Create a BiometricKey button for PasscodeScreen
+
+```kotlin
+@Composable
+fun BiometricKey(
+    modifier: Modifier,
+    passcodeManager: PasscodeManager,
+    onUserNotRegistered: () -> Unit,
+    onAuthenticationError: (String) -> Unit,
+    biometricStorageAdapter: BiometricStorageAdapter = koinInject(),
+) {
+    val authProvider = platformAuthenticationProvider.current
+    val scope = rememberCoroutineScope()
+
+    PasscodeKey(
+        modifier = modifier,
+        keyIcon = Icons.Default.Fingerprint,
+        onClick = {
+            scope.launch {
+                val result = authProvider.onAuthenticatorClick(
+                    "Unlock with Biometrics",
+                    biometricStorageAdapter.loadRegistrationData() ?: "",
+                )
+                when (result) {
+                    AuthenticationResult.Success -> passcodeManager.notifyExternalAuthSuccess()
+                    is AuthenticationResult.Error -> onAuthenticationError(result.message)
+                    AuthenticationResult.UserNotRegistered -> {
+                        passcodeManager.setExternalAuthEnabled(false)
+                        biometricStorageAdapter.deleteRegistrationData()
+                        onUserNotRegistered()
+                    }
+                    AuthenticationResult.UserCancelled -> { }
+                }
+            }
+        },
+    )
+}
+```
+
+### 4. Pass it to PasscodeScreen
+
+```kotlin
+PasscodeScreen(
+    passcodeManager = passcodeManager,
+    onResult = { result ->
+        when (result) {
+            PasscodeResult.Verified -> navController.navigate(HomeScreen)
+            PasscodeResult.Created -> navController.navigate(BiometricSetupScreen)
+            PasscodeResult.Changed -> navController.navigate(HomeScreen)
+            PasscodeResult.Forgotten -> {
+                biometricStorageAdapter.deleteRegistrationData()
+                navController.navigate(LoginScreen)
+            }
+            PasscodeResult.ExternalAuthDisabled -> {
+                biometricStorageAdapter.deleteRegistrationData()
+                navController.popBackStack()
+            }
+            PasscodeResult.Rejected -> { }
+        }
+    },
+    externalAuthButton = { modifier ->
+        BiometricKey(
+            modifier = modifier,
+            passcodeManager = passcodeManager,
+            onUserNotRegistered = { showDialog("Not registered") },
+            onAuthenticationError = { msg -> showDialog(msg) },
+        )
+    },
+)
+```
+
+### 5. Enable/Disable from HomeScreen
+
+```kotlin
+// Enable biometrics
+val result = platformAuthenticationProvider.registerUser("user", "email", "name")
+if (result is RegistrationResult.Success) {
+    biometricStorageAdapter.saveRegistrationData(result.message)
+    passcodeManager.setExternalAuthEnabled(true)
+}
+
+// Disable biometrics (starts passcode verification)
+passcodeManager.disableExternalAuth()
+navigateToPasscodeScreen()
+
+// On logout — clean up both
+biometricStorageAdapter.deleteRegistrationData()
+passcodeManager.logOut()
+```
 

--- a/mifos-authenticator-biometrics/src/commonMain/kotlin/org/mifos/authenticator/biometrics/BiometricStorageAdapter.kt
+++ b/mifos-authenticator-biometrics/src/commonMain/kotlin/org/mifos/authenticator/biometrics/BiometricStorageAdapter.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
+ */
+package org.mifos.authenticator.biometrics
+
+/**
+ * An interface for persisting biometric registration data (e.g. FIDO/WebAuthn credentials).
+ *
+ * Implementations should store data securely using platform-appropriate mechanisms
+ * (e.g. EncryptedSharedPreferences on Android, Keychain on iOS).
+ */
+interface BiometricStorageAdapter {
+    /**
+     * Saves biometric registration data to persistent storage.
+     *
+     * @param registrationData The registration data string to be saved.
+     */
+    fun saveRegistrationData(registrationData: String)
+
+    /**
+     * Loads the stored biometric registration data from persistent storage.
+     *
+     * @return The loaded registration data, or `null` if none is stored.
+     */
+    fun loadRegistrationData(): String?
+
+    /**
+     * Deletes the biometric registration data from persistent storage.
+     */
+    fun deleteRegistrationData()
+}

--- a/mifos-authenticator-passcode/README.md
+++ b/mifos-authenticator-passcode/README.md
@@ -14,7 +14,7 @@ Ensure you have the `io.github.openmf:mifos-authenticator-passcode` library adde
 
 ### 1. Implement `PasscodeStorageAdapter`
 
-First, you need to provide an implementation of `PasscodeStorageAdapter` to handle the persistence of the passcode and biometric registration data.
+Provide an implementation of `PasscodeStorageAdapter` to handle passcode persistence.
 
 ```kotlin
 import org.mifos.authenticator.passcode.PasscodeStorageAdapter
@@ -26,60 +26,31 @@ class MyPasscodeStorage : PasscodeStorageAdapter {
 
     override fun loadPasscode(): String? {
         // Return the saved passcode or null if not set
-        return "saved_passcode" 
+        return null
     }
 
     override fun deletePasscode() {
         // Remove the passcode from storage
-    }
-
-    override fun saveRegistrationData(data: String) {
-        // Save biometric registration data (e.g. public key, credential ID)
-    }
-
-    override fun loadRegistrationData(): String? {
-        // Load biometric registration data
-        return null
-    }
-
-    override fun deleteRegistrationData() {
-        // Delete biometric registration data
     }
 }
 ```
 
 ### 2. Initialize `PasscodeManager`
 
-#### Without dependency injection
-
-In your navigation graph or parent Composable, create an instance of `PasscodeManager` using the provided `rememberPasscodeManager` helper. It handles initialization automatically and ties the manager's lifecycle to the Composable.
+`PasscodeManager` should be scoped as a singleton via your DI framework since it is used across multiple screens.
 
 ```kotlin
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import org.mifos.authenticator.passcode.rememberPasscodeManager
-
-// Inside your Composable
-val scope = rememberCoroutineScope()
-val passcodeStorageAdapter = remember { MyPasscodeStorage() } // Or obtained via DI
-
-val passcodeManager = rememberPasscodeManager(
-    adapter = passcodeStorageAdapter,
-    scope = scope
-)
-```
-
-#### With dependency injection (e.g. Koin)
-
-When `PasscodeManager` is registered as a **singleton**, it must be initialized exactly once — at creation time inside the DI module.
-
-```kotlin
-// DI module
-single { PasscodeManager(get(), MainScope()).initialize() }
+// DI module (e.g. Koin)
+single {
+    PasscodeManager(
+        adapter = get<PasscodeStorageAdapter>(),
+        isExternalAuthEnabled = false, // set to true if external auth (e.g. biometrics) is registered
+    )
+}
 ```
 
 ```kotlin
-// NavGraph PasscodeScreen entry — inject without re-initializing
+// Inject in any screen
 val passcodeManager = koinInject<PasscodeManager>()
 ```
 
@@ -99,95 +70,116 @@ val startDestination = if (isUsingPasscode) {
 
 ### 4. Implement the `PasscodeScreen`
 
-Add the `PasscodeScreen` to your navigation graph. You need to handle several callbacks to define what happens after specific events.
+Add the `PasscodeScreen` to your navigation graph. All outcomes are delivered via a single `onResult` callback.
 
 ```kotlin
 import org.mifos.authenticator.passcode.screen.PasscodeScreen
+import org.mifos.authenticator.passcode.PasscodeResult
 
 composable<Route.PasscodeScreen> {
     PasscodeScreen(
         passcodeManager = passcodeManager,
-        // Called when the user successfully enters the correct passcode or uses biometrics
-        onPasscodeConfirm = {
-            navController.popBackStack()
-            navController.navigate(Route.HomeScreen)
+        onResult = { result ->
+            when (result) {
+                PasscodeResult.Verified -> navController.navigate(Route.HomeScreen)
+                PasscodeResult.Created -> navController.navigate(Route.BiometricSetupScreen)
+                PasscodeResult.Changed -> navController.navigate(Route.HomeScreen)
+                PasscodeResult.Forgotten -> navController.navigate(Route.LoginScreen)
+                PasscodeResult.ExternalAuthDisabled -> navController.popBackStack()
+                PasscodeResult.Rejected -> { /* optional: vibrate device */ }
+            }
         },
-        // Called when the user taps "Forgot Passcode?"
-        onForgotButton = {
-            navController.navigate(Route.LoginScreen)
+        // Optional: Provide a custom external auth button (e.g. biometrics)
+        externalAuthButton = { modifier ->
+            MyBiometricKey(modifier, passcodeManager)
         },
-        // Called when a new passcode is successfully created and confirmed
-        onPasscodeCreation = {
-            navController.navigate(Route.BiometricSetupScreen) // Suggest biometrics after passcode setup
-        },
-        // Called when an existing passcode is successfully changed
-        onPasscodeChanged = {
-            navController.popBackStack()
-        },
-        // Called when the entered passcode is incorrect
-        onPasscodeRejected = {
-            // e.g. Vibrate device
-        },
-        // Called when biometrics are successfully disabled
-        onDisableBiometrics = {
-            navController.popBackStack()
-        },
-        // Called when a biometric error occurs
-        onBiometricError = { message ->
-            // Show error message
-        },
-        // Optional: Provide a custom biometric button component
-        biometricButton = { modifier ->
-            BiometricKey(modifier, passcodeManager)
-        }
     )
 }
 ```
 
-### 5. Biometric Integration
+### 5. External Authentication Integration (e.g. Biometrics)
 
-To enable biometrics, you need to use a platform-specific biometric provider (like `mifos-authenticator-biometrics`) and send actions to `PasscodeManager`.
+The passcode library is agnostic to the external auth mechanism. It only needs to know:
+- Whether external auth is enabled (controls button visibility)
+- When external auth succeeds (bypasses passcode entry)
 
-#### Enabling Biometrics:
+#### Enabling External Auth:
 ```kotlin
-// After successful biometric registration on the platform:
-passcodeManager.trySendAction(PasscodeAction.SaveBiometricRegistration(registrationData))
+// After successful biometric/external auth registration:
+biometricStorageAdapter.saveRegistrationData(registrationData)
+passcodeManager.setExternalAuthEnabled(true)
 ```
 
-#### Unlocking with Biometrics:
-When the user clicks the biometric button on the `PasscodeScreen`:
+#### Unlocking with External Auth:
+Handle authentication in your external auth button component:
 ```kotlin
 // In your BiometricKey component:
 val result = platformAuthenticator.authenticate(...)
-if (result is Success) {
-    passcodeManager.trySendAction(PasscodeAction.BiometricUnlockSuccess)
-} else {
-    passcodeManager.trySendAction(PasscodeAction.BiometricUnlockFailure(result.message))
+when (result) {
+    is Success -> passcodeManager.notifyExternalAuthSuccess()
+    is Error -> showErrorDialog(result.message)         // handle locally
+    UserNotRegistered -> {
+        passcodeManager.setExternalAuthEnabled(false)   // hide button
+        storageAdapter.deleteRegistrationData()          // clean up
+    }
+    UserCancelled -> { /* no-op */ }
 }
 ```
 
+#### Disabling External Auth:
+```kotlin
+// From a settings screen — starts passcode verification flow
+passcodeManager.disableExternalAuth()
+navigateToPasscodeScreen()
+
+// Then in onResult callback, clean up storage:
+PasscodeResult.ExternalAuthDisabled -> {
+    storageAdapter.deleteRegistrationData()
+    navController.popBackStack()
+}
+```
+
+### 6. Common Operations from Other Screens
+
+#### Change Passcode:
+```kotlin
+// From HomeScreen or SettingsScreen
+passcodeManager.changePasscode()
+navController.navigate(Route.PasscodeScreen)
+// PasscodeScreen will show "Confirm old passcode" → "Create new passcode" → "Confirm new passcode"
+// On success, onResult receives PasscodeResult.Changed
+```
+
+#### Log Out:
+```kotlin
+// Clears passcode silently — no PasscodeResult emitted
+passcodeManager.logOut()
+navController.navigate(Route.LoginScreen)
+```
+
+---
+
 ## Summary of Key Components
 
-*   **`PasscodeStorageAdapter`**: Interface you must implement for storage logic (Passcode & Biometrics).
-*   **`PasscodeManager`**: State holder for the passcode logic.
-*   **`PasscodeScreen`**: The UI Composable provided by the library.
+*   **`PasscodeStorageAdapter`**: Interface for passcode persistence.
+*   **`PasscodeManager`**: State holder and logic for passcode operations.
+*   **`PasscodeScreen`**: The UI composable provided by the library.
+*   **`PasscodeResult`**: Sealed interface for all operation outcomes.
 
-### Key `PasscodeAction`s:
-- `ChangePasscode`: Initiates the passcode change flow.
-- `ForgetPasscode`: Deletes passcode/biometrics and resets to Create mode (emits `OnPasscodeDeletion`).
-- `LogOutErase`: Silently erases all security data (no event emitted).
-- `DisableBiometrics`: Initiates the flow to disable biometrics (requires passcode verification).
-- `UpdatePasscodeLength(length)`: Changes the required passcode length (4 or 6).
-- `BiometricUnlockSuccess`: Signals successful biometric authentication.
-- `SaveBiometricRegistration(data)`: Saves biometric registration data and enables biometrics in state.
+### `PasscodeManager` Methods:
+- `changePasscode()`: Initiates the passcode change flow.
+- `logOut()`: Silently clears the passcode (no result emitted).
+- `disableExternalAuth()`: Starts passcode verification to disable external auth.
+- `notifyExternalAuthSuccess()`: Signals successful external authentication.
+- `setExternalAuthEnabled(enabled)`: Controls external auth button visibility.
 
-### Key `PasscodeEvent`s:
-- `OnUnlockSuccess`: Emitted on successful passcode or biometric entry.
-- `OnPasscodeCreateSuccess`: Emitted after initial passcode setup.
-- `OnPasscodeChanged`: Emitted after a passcode change.
-- `OnPasscodeDeletion`: Emitted after `ForgetPasscode` action.
-- `OnRejectEnteredPasscode`: Emitted on incorrect passcode entry.
-- `OnBiometricUnlockFailure`: Emitted when biometric unlock fails.
+### `PasscodeResult` Values:
+- `Verified`: Passcode entered correctly or external auth succeeded.
+- `Created`: New passcode created and confirmed.
+- `Changed`: Existing passcode changed.
+- `ExternalAuthDisabled`: External auth disabled after passcode verification.
+- `Forgotten`: Passcode deleted via "Forgot Passcode?" button.
+- `Rejected`: Incorrect passcode entered.
 
 ## Customization
 

--- a/mifos-authenticator-passcode/src/commonMain/composeResources/values/strings.xml
+++ b/mifos-authenticator-passcode/src/commonMain/composeResources/values/strings.xml
@@ -23,8 +23,8 @@
     <string name="drag_guide">drag_guide</string>
     <string name="drag_passcode">drag_passcode</string>
     <string name="drag_your_pattern">drag_your_pattern</string>
-    <string name="enable_biometric_dialog_description">enable_biometric_dialog_description</string>
-    <string name="enable_biometric_dialog_title">enable_biometric_dialog_title</string>
+    <string name="enable_external_auth_dialog_description">enable_external_auth_dialog_description</string>
+    <string name="enable_external_auth_dialog_title">enable_external_auth_dialog_title</string>
     <string name="enter_your_passcode">Enter your passcode</string>
     <string name="exit">Exit</string>
     <string name="forgot_passcode">Forgot Passcode?</string>

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
@@ -9,40 +9,11 @@
  */
 package org.mifos.authenticator.passcode
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import org.mifos.authenticator.passcode.screen.PasscodeScreen
 import org.mifos.authenticator.passcode.utility.PasscodeLength
-
-/**
- * Remembers and provides a [PasscodeManager] instance within a Compose composition.
- *
- * This function handles the lifecycle of the [PasscodeManager], ensuring it is
- * properly initialized and remembered across recompositions.
- *
- * @param adapter The [PasscodeStorageAdapter] to use for persisting and loading passcodes.
- * @param scope The [CoroutineScope] to launch coroutines for handling passcode actions and events.
- * @param isExternalAuthEnabled Whether external authentication (e.g. biometrics) is registered.
- * @return An initialized [PasscodeManager] instance.
- */
-@Composable
-fun rememberPasscodeManager(
-    adapter: PasscodeStorageAdapter,
-    scope: CoroutineScope,
-    isExternalAuthEnabled: Boolean = false,
-): PasscodeManager {
-    return remember(scope) {
-        PasscodeManager(adapter, scope).initialize(isExternalAuthEnabled)
-    }
-}
 
 /**
  * Manages the state and logic for passcode creation, entry, and validation.
@@ -51,16 +22,22 @@ fun rememberPasscodeManager(
  * - Initial passcode setup (Creation and Confirmation)
  * - Passcode verification for app unlock
  * - Changing the existing passcode
- * - Enabling/Disabling external authentication (e.g. biometrics)
+ * - Disabling external authentication (e.g. biometrics) with passcode verification
  *
- * @property adapter The storage adapter used for persisting passcode and external auth data.
- * @property scope Coroutine scope for internal processing and event emission.
+ * Results are delivered via a [PasscodeResult] callback registered by [PasscodeScreen].
+ * Use [onResult] in [PasscodeScreen] to handle navigation and other outcomes.
+ *
+ * This class should be scoped as a singleton via your DI framework (Koin, Hilt, etc.)
+ * since it is used across multiple screens.
+ *
+ * @param adapter The [PasscodeStorageAdapter] used for persisting and loading passcodes.
+ * @param isExternalAuthEnabled Whether external authentication (e.g. biometrics) is currently
+ *        registered. The caller should check this via their own storage (e.g. BiometricStorageAdapter).
  */
 class PasscodeManager(
     private val adapter: PasscodeStorageAdapter,
-    private val scope: CoroutineScope,
+    private val isExternalAuthEnabled: Boolean = false,
 ) {
-
     private val _state = MutableStateFlow(
         PasscodeState(
             loadedPasscode = adapter.loadPasscode(),
@@ -72,41 +49,12 @@ class PasscodeManager(
      */
     val state = _state.asStateFlow()
 
-    private val _events = Channel<PasscodeEvent>(capacity = Channel.UNLIMITED)
-
-    /**
-     * A flow of [PasscodeEvent]s emitted by the manager (e.g., success, failure, deletion).
-     */
-    val events = _events.receiveAsFlow()
-
-    private val _actions = Channel<PasscodeAction>(capacity = Channel.UNLIMITED)
-
-    /**
-     * A [SendChannel] to send [PasscodeAction]s to the manager.
-     */
-    val actions: SendChannel<PasscodeAction> = _actions
-
-    init {
-        scope.launch {
-            _actions.consumeAsFlow().collect { action ->
-                handleAction(action)
-            }
-        }
-    }
+    private var onResult: ((PasscodeResult) -> Unit)? = null
 
     private val creationPasscodeBuilder = StringBuilder()
     private val finalConfirmationPasscodeBuilder = StringBuilder()
 
-    /**
-     * Initializes the [PasscodeManager] by loading existing data and setting the initial step.
-     *
-     * Should be called once after creation, especially when not using [rememberPasscodeManager].
-     *
-     * @param isExternalAuthEnabled Whether external authentication (e.g. biometrics) is registered.
-     *        The caller should check this via their own storage (e.g. [BiometricStorageAdapter]).
-     * @return The initialized [PasscodeManager] instance.
-     */
-    fun initialize(isExternalAuthEnabled: Boolean = false): PasscodeManager {
+    init {
         val loaded = adapter.loadPasscode()
 
         when {
@@ -136,56 +84,81 @@ class PasscodeManager(
                 }
             }
         }
-        return this
     }
 
-    private fun handleAction(action: PasscodeAction) {
-        when (action) {
-            PasscodeAction.ChangePasscode -> changePasscode()
-            PasscodeAction.DisableExternalAuth -> disableExternalAuth()
-            PasscodeAction.DeleteAllKeys -> deleteAllKeys()
-            PasscodeAction.DeleteKey -> deleteKey()
-            is PasscodeAction.EnterKey -> enterKey(action.key)
-            PasscodeAction.ForgetPasscode -> {
-                clearAllSecurityData()
-                emitEvent(PasscodeEvent.OnPasscodeDeletion)
-            }
-            PasscodeAction.TogglePasscodeVisibility -> togglePasscodeVisibility()
-            is PasscodeAction.UpdatePasscodeLength -> updatePasscodeLength(action.length)
-            PasscodeAction.LogOutErase -> {
-                clearAllSecurityData()
-            }
-            PasscodeAction.LogOutErasePasscode -> {
-                clearAllSecurityData()
-            }
-            PasscodeAction.ExternalUnlockSuccess -> {
-                if (_state.value.passcodeStep == PasscodeStep.Enter) {
-                    emitEvent(PasscodeEvent.OnUnlockSuccess)
-                }
-            }
-            is PasscodeAction.ExternalUnlockFailure -> {
-                if (_state.value.passcodeStep == PasscodeStep.Enter) {
-                    emitEvent(PasscodeEvent.OnExternalUnlockFailure(action.message))
-                }
-            }
-            PasscodeAction.ExternalAuthNotAvailable -> {
-                clearExternalRegistration()
-                if (_state.value.passcodeStep == PasscodeStep.Enter) {
-                    emitEvent(PasscodeEvent.OnExternalAuthNotAvailable)
-                }
-            }
-            is PasscodeAction.SaveExternalRegistration -> {
-                updateState { it.copy(isExternalAuthEnabled = true) }
-            }
-            PasscodeAction.DeleteExternalRegistration -> clearExternalRegistration()
-        }
+    /**
+     * Initiates the change passcode flow. Sets the step to [PasscodeStep.ChangeVerify],
+     * requiring the user to verify their current passcode before creating a new one.
+     *
+     * After successful verification and confirmation, [PasscodeResult.Changed] is emitted.
+     */
+    fun changePasscode() {
+        updateState { it.copy(passcodeStep = PasscodeStep.ChangeVerify, isChangeFlow = true) }
     }
 
-    private fun updatePasscodeLength(length: PasscodeLength) {
+    /**
+     * Clears the stored passcode and resets the manager to the creation state.
+     * No [PasscodeResult] is emitted — the caller handles navigation directly.
+     *
+     * Use this for logout flows from screens other than [PasscodeScreen].
+     */
+    fun logOut() {
+        clearAllSecurityData()
+    }
+
+    /**
+     * Initiates the disable external auth flow. Sets the step to [PasscodeStep.DisableExternalAuth],
+     * requiring the user to verify their passcode before external auth is disabled.
+     *
+     * After successful verification, [PasscodeResult.ExternalAuthDisabled] is emitted.
+     * The caller should then delete external auth registration data from their storage.
+     */
+    fun disableExternalAuth() {
+        updateState { it.copy(passcodeStep = PasscodeStep.DisableExternalAuth) }
+    }
+
+    /**
+     * Notifies the manager that external authentication (e.g. biometrics) succeeded.
+     * Emits [PasscodeResult.Verified], bypassing passcode entry.
+     *
+     * Call this from your external auth button when authentication is successful.
+     */
+    fun notifyExternalAuthSuccess() {
+        emitResult(PasscodeResult.Verified)
+    }
+
+    /**
+     * Updates whether external authentication is enabled. Controls the visibility
+     * of the external auth button on [PasscodeScreen].
+     *
+     * @param enabled `true` to show the external auth button, `false` to hide it.
+     */
+    fun setExternalAuthEnabled(enabled: Boolean) {
+        updateState { it.copy(isExternalAuthEnabled = enabled) }
+    }
+
+    /**
+     * Registers a callback to receive [PasscodeResult]s.
+     * Called by [PasscodeScreen] via [DisposableEffect] — not intended for consumer use.
+     */
+    internal fun setResultCallback(callback: ((PasscodeResult) -> Unit)?) {
+        onResult = callback
+    }
+
+    /**
+     * Clears the stored passcode and emits [PasscodeResult.Forgotten].
+     * Called by the "Forgot Passcode?" button inside [PasscodeScreen].
+     */
+    internal fun forgetPasscode() {
+        clearAllSecurityData()
+        emitResult(PasscodeResult.Forgotten)
+    }
+
+    internal fun updatePasscodeLength(length: PasscodeLength) {
         updateState { it.copy(passcodeLength = length) }
     }
 
-    private fun deleteKey() {
+    internal fun deleteKey() {
         val passcodeBuilder = getActivePasscodeBuilder()
         if (passcodeBuilder.isNotEmpty()) {
             passcodeBuilder.deleteAt(passcodeBuilder.length - 1)
@@ -198,12 +171,12 @@ class PasscodeManager(
         }
     }
 
-    private fun deleteAllKeys() {
+    internal fun deleteAllKeys() {
         getActivePasscodeBuilder().clear()
         updateState { it.copy(currentPasscodeInput = "", filledDots = 0) }
     }
 
-    private fun enterKey(key: String) {
+    internal fun enterKey(key: String) {
         val currentState = _state.value
         if (currentState.filledDots >= _state.value.passcodeLength.length) return
 
@@ -222,16 +195,8 @@ class PasscodeManager(
         }
     }
 
-    private fun togglePasscodeVisibility() {
+    internal fun togglePasscodeVisibility() {
         updateState { it.copy(passcodeVisible = !_state.value.passcodeVisible) }
-    }
-
-    private fun changePasscode() {
-        updateState { it.copy(passcodeStep = PasscodeStep.ChangeVerify, isChangeFlow = true) }
-    }
-
-    private fun disableExternalAuth() {
-        updateState { it.copy(passcodeStep = PasscodeStep.DisableExternalAuth) }
     }
 
     private fun handleCompletedPasscodeEntry() {
@@ -256,6 +221,10 @@ class PasscodeManager(
         }
     }
 
+    private fun emitResult(result: PasscodeResult) {
+        onResult?.invoke(result)
+    }
+
     private fun handleChangeVerifyPasscode() {
         val loadedPasscode = adapter.loadPasscode()
         if (finalConfirmationPasscodeBuilder.toString() == loadedPasscode) {
@@ -270,7 +239,10 @@ class PasscodeManager(
                 )
             }
         } else {
-            emitEvent(PasscodeEvent.OnRejectEnteredPasscode)
+            updateState {
+                it.copy(shakeAnimationTrigger = it.shakeAnimationTrigger + 1)
+            }
+            emitResult(PasscodeResult.Rejected)
         }
         resetPasscodeEntryStates()
     }
@@ -278,11 +250,13 @@ class PasscodeManager(
     private fun handleDisableExternalAuthVerification() {
         val loadedPasscode = adapter.loadPasscode()
         if (finalConfirmationPasscodeBuilder.toString() == loadedPasscode) {
-            clearExternalRegistration()
             updateState { it.copy(passcodeStep = PasscodeStep.Enter) }
-            emitEvent(PasscodeEvent.OnDisableExternalAuthSuccess)
+            emitResult(PasscodeResult.ExternalAuthDisabled)
         } else {
-            emitEvent(PasscodeEvent.OnRejectEnteredPasscode)
+            updateState {
+                it.copy(shakeAnimationTrigger = it.shakeAnimationTrigger + 1)
+            }
+            emitResult(PasscodeResult.Rejected)
         }
         resetPasscodeEntryStates()
     }
@@ -315,22 +289,28 @@ class PasscodeManager(
             }
             creationPasscodeBuilder.clear()
             if (isChange) {
-                emitEvent(PasscodeEvent.OnPasscodeChanged)
+                emitResult(PasscodeResult.Changed)
             } else {
-                emitEvent(PasscodeEvent.OnPasscodeCreateSuccess)
+                emitResult(PasscodeResult.Created)
             }
         } else {
             updateState { it.copy(currentPasscodeInput = "", filledDots = 0) }
-            emitEvent(PasscodeEvent.OnRejectConfirmationPasscode)
+
+            updateState {
+                it.copy(shakeAnimationTrigger = it.shakeAnimationTrigger + 1)
+            }
         }
         resetPasscodeEntryStates()
     }
 
     private fun handleEnterPasscode() {
         if (finalConfirmationPasscodeBuilder.toString() == _state.value.loadedPasscode) {
-            emitEvent(PasscodeEvent.OnUnlockSuccess)
+            emitResult(PasscodeResult.Verified)
         } else {
-            emitEvent(PasscodeEvent.OnRejectEnteredPasscode)
+            emitResult(PasscodeResult.Rejected)
+            updateState {
+                it.copy(shakeAnimationTrigger = it.shakeAnimationTrigger + 1)
+            }
         }
         resetPasscodeEntryStates()
     }
@@ -354,32 +334,11 @@ class PasscodeManager(
     private fun clearAllSecurityData() {
         adapter.deletePasscode()
         updateState { it.copy(loadedPasscode = null, passcodeStep = PasscodeStep.Create) }
-        clearExternalRegistration()
-        resetPasscodeEntryStates()
-    }
-
-    private fun clearExternalRegistration() {
-        updateState {
-            it.copy(isExternalAuthEnabled = false)
-        }
         resetPasscodeEntryStates()
     }
 
     private fun updateState(update: (PasscodeState) -> PasscodeState) {
         _state.update { update(it) }
-    }
-
-    private fun emitEvent(event: PasscodeEvent) = scope.launch {
-        _events.send(event)
-    }
-
-    /**
-     * Sends a [PasscodeAction] to the manager's action channel.
-     *
-     * @param action The action to send.
-     */
-    fun trySendAction(action: PasscodeAction) {
-        actions.trySend(action)
     }
 }
 
@@ -403,118 +362,32 @@ data class PasscodeState(
     val loadedPasscode: String? = null,
     val passcodeStep: PasscodeStep = PasscodeStep.Unset,
     val isChangeFlow: Boolean = false,
+    val shakeAnimationTrigger: Int = 0,
     val isExternalAuthEnabled: Boolean = false,
 )
 
 /**
- * Events emitted by the [PasscodeManager] to notify the UI or other components of state changes.
+ * Results emitted by [PasscodeManager] to indicate the outcome of a passcode operation.
+ * Delivered via the `onResult` callback in [PasscodeScreen].
  */
-sealed interface PasscodeEvent {
-    /** Emitted when the passcode or external authentication is successful. */
-    object OnUnlockSuccess : PasscodeEvent
+sealed interface PasscodeResult {
+    /** Passcode entered correctly or external authentication succeeded. */
+    data object Verified : PasscodeResult
 
-    /** Emitted when a new passcode is successfully created and confirmed for the first time. */
-    object OnPasscodeCreateSuccess : PasscodeEvent
+    /** New passcode created and confirmed for the first time. */
+    data object Created : PasscodeResult
 
-    /** Emitted when an existing passcode is successfully changed. */
-    object OnPasscodeChanged : PasscodeEvent
+    /** Existing passcode changed successfully. */
+    data object Changed : PasscodeResult
 
-    /** Emitted when external authentication is successfully disabled. */
-    object OnDisableExternalAuthSuccess : PasscodeEvent
+    /** External auth disabled after passcode verification. Caller should delete registration data. */
+    data object ExternalAuthDisabled : PasscodeResult
 
-    /** Emitted when an incorrect passcode is entered during the unlock or change verification flow. */
-    object OnRejectEnteredPasscode : PasscodeEvent
+    /** Passcode deleted via "Forgot Passcode?" button. */
+    data object Forgotten : PasscodeResult
 
-    /** Emitted when the confirmation passcode does not match the creation passcode. */
-    object OnRejectConfirmationPasscode : PasscodeEvent
-
-    /** Emitted when the passcode is deleted (e.g., via "Forgot Passcode"). */
-    object OnPasscodeDeletion : PasscodeEvent
-
-    /**
-     * Emitted when external authentication fails.
-     * @property message An optional error message explaining the failure.
-     */
-    data class OnExternalUnlockFailure(val message: String?) : PasscodeEvent
-
-    /** Emitted when an external unlock is attempted but the user is not registered. */
-    object OnExternalAuthNotAvailable : PasscodeEvent
-}
-
-/**
- * Actions that can be sent to the [PasscodeManager] to trigger logic.
- */
-sealed interface PasscodeAction {
-    /**
-     * Action for the "Forgot Passcode?" flow inside [PasscodeScreen].
-     *
-     * Deletes the stored passcode, resets the manager state to [PasscodeStep.Create],
-     * and emits [PasscodeEvent.OnPasscodeDeletion] so the screen can navigate away.
-     * **Only dispatch this action when [PasscodeScreen] is active** (i.e. when there is an active
-     * collector on [PasscodeManager.events]). Dispatching it while [PasscodeScreen] is not in the
-     * back stack will buffer the event; it will then fire immediately the next time the screen
-     * is opened, sending the user back to login before they can interact.
-     */
-    object ForgetPasscode : PasscodeAction
-
-    /**
-     * Action to erase the stored passcode during a logout flow from outside [PasscodeScreen].
-     *
-     * Calls the [PasscodeStorageAdapter] to delete the passcode directly without emitting any
-     * event. Use this instead of [ForgetPasscode] whenever [PasscodeScreen] is not currently
-     * in the back stack (e.g. a logout button on a Home or Settings screen).
-     */
-    object LogOutErasePasscode : PasscodeAction
-
-    object LogOutErase : PasscodeAction
-
-    /** Initiates the flow to change the existing passcode. */
-    object ChangePasscode : PasscodeAction
-
-    /** Toggles the visibility of the entered passcode characters. */
-    object TogglePasscodeVisibility : PasscodeAction
-
-    /** Deletes the last entered digit. */
-    object DeleteKey : PasscodeAction
-
-    /** Deletes all currently entered digits in the current step. */
-    object DeleteAllKeys : PasscodeAction
-
-    /**
-     * Enters a single digit.
-     * @property key The digit to enter.
-     */
-    data class EnterKey(val key: String) : PasscodeAction
-
-    /**
-     * Updates the required passcode length.
-     * @property length The new length ([PasscodeLength.FOUR_DIGIT] or [PasscodeLength.SIX_DIGIT]).
-     */
-    data class UpdatePasscodeLength(val length: PasscodeLength) : PasscodeAction
-
-    /** Signals a successful external authentication (e.g. biometrics). */
-    object ExternalUnlockSuccess : PasscodeAction
-
-    /**
-     * Signals a failed external authentication.
-     * @property message An optional error message.
-     */
-    data class ExternalUnlockFailure(val message: String? = null) : PasscodeAction
-
-    /** Signals that the user is not registered for external authentication. */
-    object ExternalAuthNotAvailable : PasscodeAction
-
-    /** Initiates the flow to disable external authentication (requires passcode verification). */
-    object DisableExternalAuth : PasscodeAction
-
-    /**
-     * Saves external authentication registration data.
-     * @property registrationData The opaque data string to save.
-     */
-    data class SaveExternalRegistration(val registrationData: String) : PasscodeAction
-
-    /** Deletes stored external authentication registration data. */
-    object DeleteExternalRegistration : PasscodeAction
+    /** Incorrect passcode entered. */
+    data object Rejected : PasscodeResult
 }
 
 /**

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
@@ -30,15 +30,17 @@ import org.mifos.authenticator.passcode.utility.PasscodeLength
  *
  * @param adapter The [PasscodeStorageAdapter] to use for persisting and loading passcodes.
  * @param scope The [CoroutineScope] to launch coroutines for handling passcode actions and events.
+ * @param isExternalAuthEnabled Whether external authentication (e.g. biometrics) is registered.
  * @return An initialized [PasscodeManager] instance.
  */
 @Composable
 fun rememberPasscodeManager(
     adapter: PasscodeStorageAdapter,
     scope: CoroutineScope,
+    isExternalAuthEnabled: Boolean = false,
 ): PasscodeManager {
     return remember(scope) {
-        PasscodeManager(adapter, scope).initialize()
+        PasscodeManager(adapter, scope).initialize(isExternalAuthEnabled)
     }
 }
 
@@ -49,9 +51,9 @@ fun rememberPasscodeManager(
  * - Initial passcode setup (Creation and Confirmation)
  * - Passcode verification for app unlock
  * - Changing the existing passcode
- * - Enabling/Disabling biometric authentication
+ * - Enabling/Disabling external authentication (e.g. biometrics)
  *
- * @property adapter The storage adapter used for persisting passcode and biometric data.
+ * @property adapter The storage adapter used for persisting passcode and external auth data.
  * @property scope Coroutine scope for internal processing and event emission.
  */
 class PasscodeManager(
@@ -100,11 +102,12 @@ class PasscodeManager(
      *
      * Should be called once after creation, especially when not using [rememberPasscodeManager].
      *
+     * @param isExternalAuthEnabled Whether external authentication (e.g. biometrics) is registered.
+     *        The caller should check this via their own storage (e.g. [BiometricStorageAdapter]).
      * @return The initialized [PasscodeManager] instance.
      */
-    fun initialize(): PasscodeManager {
+    fun initialize(isExternalAuthEnabled: Boolean = false): PasscodeManager {
         val loaded = adapter.loadPasscode()
-        val biometricRegistered = adapter.loadRegistrationData() != null
 
         when {
             loaded != null -> {
@@ -112,7 +115,7 @@ class PasscodeManager(
                     it.copy(
                         loadedPasscode = loaded,
                         passcodeStep = PasscodeStep.Enter,
-                        isBiometricEnabled = biometricRegistered,
+                        isExternalAuthEnabled = isExternalAuthEnabled,
                     )
                 }
                 updatePasscodeLength(
@@ -128,7 +131,7 @@ class PasscodeManager(
                 updateState {
                     it.copy(
                         passcodeStep = PasscodeStep.Create,
-                        isBiometricEnabled = biometricRegistered,
+                        isExternalAuthEnabled = isExternalAuthEnabled,
                     )
                 }
             }
@@ -139,7 +142,7 @@ class PasscodeManager(
     private fun handleAction(action: PasscodeAction) {
         when (action) {
             PasscodeAction.ChangePasscode -> changePasscode()
-            PasscodeAction.DisableBiometrics -> disableBiometrics()
+            PasscodeAction.DisableExternalAuth -> disableExternalAuth()
             PasscodeAction.DeleteAllKeys -> deleteAllKeys()
             PasscodeAction.DeleteKey -> deleteKey()
             is PasscodeAction.EnterKey -> enterKey(action.key)
@@ -155,27 +158,26 @@ class PasscodeManager(
             PasscodeAction.LogOutErasePasscode -> {
                 clearAllSecurityData()
             }
-            PasscodeAction.BiometricUnlockSuccess -> {
+            PasscodeAction.ExternalUnlockSuccess -> {
                 if (_state.value.passcodeStep == PasscodeStep.Enter) {
                     emitEvent(PasscodeEvent.OnUnlockSuccess)
                 }
             }
-            is PasscodeAction.BiometricUnlockFailure -> {
+            is PasscodeAction.ExternalUnlockFailure -> {
                 if (_state.value.passcodeStep == PasscodeStep.Enter) {
-                    emitEvent(PasscodeEvent.OnBiometricUnlockFailure(action.message))
+                    emitEvent(PasscodeEvent.OnExternalUnlockFailure(action.message))
                 }
             }
-            PasscodeAction.BiometricUserNotRegistered -> {
-                clearBiometricRegistration()
+            PasscodeAction.ExternalAuthNotAvailable -> {
+                clearExternalRegistration()
                 if (_state.value.passcodeStep == PasscodeStep.Enter) {
-                    emitEvent(PasscodeEvent.OnBiometricUserNotRegistered)
+                    emitEvent(PasscodeEvent.OnExternalAuthNotAvailable)
                 }
             }
-            is PasscodeAction.SaveBiometricRegistration -> {
-                adapter.saveRegistrationData(action.registrationData)
-                updateState { it.copy(isBiometricEnabled = true) }
+            is PasscodeAction.SaveExternalRegistration -> {
+                updateState { it.copy(isExternalAuthEnabled = true) }
             }
-            PasscodeAction.DeleteBiometricRegistration -> clearBiometricRegistration()
+            PasscodeAction.DeleteExternalRegistration -> clearExternalRegistration()
         }
     }
 
@@ -228,14 +230,14 @@ class PasscodeManager(
         updateState { it.copy(passcodeStep = PasscodeStep.ChangeVerify, isChangeFlow = true) }
     }
 
-    private fun disableBiometrics() {
-        updateState { it.copy(passcodeStep = PasscodeStep.DisableBiometrics) }
+    private fun disableExternalAuth() {
+        updateState { it.copy(passcodeStep = PasscodeStep.DisableExternalAuth) }
     }
 
     private fun handleCompletedPasscodeEntry() {
         when (_state.value.passcodeStep) {
             PasscodeStep.ChangeVerify -> handleChangeVerifyPasscode()
-            PasscodeStep.DisableBiometrics -> handleDisableBiometricsVerification()
+            PasscodeStep.DisableExternalAuth -> handleDisableExternalAuthVerification()
             PasscodeStep.Enter -> handleEnterPasscode()
             PasscodeStep.Create -> handleCreatePasscode()
             PasscodeStep.Confirm -> handleConfirmPasscode()
@@ -248,7 +250,7 @@ class PasscodeManager(
             PasscodeStep.ChangeVerify,
             PasscodeStep.Confirm,
             PasscodeStep.Enter,
-            PasscodeStep.DisableBiometrics,
+            PasscodeStep.DisableExternalAuth,
             -> finalConfirmationPasscodeBuilder
             else -> creationPasscodeBuilder
         }
@@ -273,12 +275,12 @@ class PasscodeManager(
         resetPasscodeEntryStates()
     }
 
-    private fun handleDisableBiometricsVerification() {
+    private fun handleDisableExternalAuthVerification() {
         val loadedPasscode = adapter.loadPasscode()
         if (finalConfirmationPasscodeBuilder.toString() == loadedPasscode) {
-            clearBiometricRegistration()
+            clearExternalRegistration()
             updateState { it.copy(passcodeStep = PasscodeStep.Enter) }
-            emitEvent(PasscodeEvent.OnDisableBiometricsSuccess)
+            emitEvent(PasscodeEvent.OnDisableExternalAuthSuccess)
         } else {
             emitEvent(PasscodeEvent.OnRejectEnteredPasscode)
         }
@@ -352,14 +354,13 @@ class PasscodeManager(
     private fun clearAllSecurityData() {
         adapter.deletePasscode()
         updateState { it.copy(loadedPasscode = null, passcodeStep = PasscodeStep.Create) }
-        clearBiometricRegistration()
+        clearExternalRegistration()
         resetPasscodeEntryStates()
     }
 
-    private fun clearBiometricRegistration() {
-        adapter.deleteRegistrationData()
+    private fun clearExternalRegistration() {
         updateState {
-            it.copy(isBiometricEnabled = false)
+            it.copy(isExternalAuthEnabled = false)
         }
         resetPasscodeEntryStates()
     }
@@ -392,7 +393,7 @@ class PasscodeManager(
  * @property loadedPasscode The saved passcode from storage (null if not set).
  * @property passcodeStep The current step in the passcode flow (e.g., Enter, Create, Confirm).
  * @property isChangeFlow Whether the user is currently in the process of changing their passcode.
- * @property isBiometricEnabled Whether biometric authentication is enabled and registered.
+ * @property isExternalAuthEnabled Whether external authentication (e.g. biometrics) is enabled and registered.
  */
 data class PasscodeState(
     val filledDots: Int = 0,
@@ -402,14 +403,14 @@ data class PasscodeState(
     val loadedPasscode: String? = null,
     val passcodeStep: PasscodeStep = PasscodeStep.Unset,
     val isChangeFlow: Boolean = false,
-    val isBiometricEnabled: Boolean = false,
+    val isExternalAuthEnabled: Boolean = false,
 )
 
 /**
  * Events emitted by the [PasscodeManager] to notify the UI or other components of state changes.
  */
 sealed interface PasscodeEvent {
-    /** Emitted when the passcode or biometric authentication is successful. */
+    /** Emitted when the passcode or external authentication is successful. */
     object OnUnlockSuccess : PasscodeEvent
 
     /** Emitted when a new passcode is successfully created and confirmed for the first time. */
@@ -418,8 +419,8 @@ sealed interface PasscodeEvent {
     /** Emitted when an existing passcode is successfully changed. */
     object OnPasscodeChanged : PasscodeEvent
 
-    /** Emitted when biometric authentication is successfully disabled. */
-    object OnDisableBiometricsSuccess : PasscodeEvent
+    /** Emitted when external authentication is successfully disabled. */
+    object OnDisableExternalAuthSuccess : PasscodeEvent
 
     /** Emitted when an incorrect passcode is entered during the unlock or change verification flow. */
     object OnRejectEnteredPasscode : PasscodeEvent
@@ -431,13 +432,13 @@ sealed interface PasscodeEvent {
     object OnPasscodeDeletion : PasscodeEvent
 
     /**
-     * Emitted when biometric authentication fails.
+     * Emitted when external authentication fails.
      * @property message An optional error message explaining the failure.
      */
-    data class OnBiometricUnlockFailure(val message: String?) : PasscodeEvent
+    data class OnExternalUnlockFailure(val message: String?) : PasscodeEvent
 
-    /** Emitted when a biometric unlock is attempted but the user is not registered. */
-    object OnBiometricUserNotRegistered : PasscodeEvent
+    /** Emitted when an external unlock is attempted but the user is not registered. */
+    object OnExternalAuthNotAvailable : PasscodeEvent
 }
 
 /**
@@ -491,29 +492,29 @@ sealed interface PasscodeAction {
      */
     data class UpdatePasscodeLength(val length: PasscodeLength) : PasscodeAction
 
-    /** Signals a successful biometric authentication. */
-    object BiometricUnlockSuccess : PasscodeAction
+    /** Signals a successful external authentication (e.g. biometrics). */
+    object ExternalUnlockSuccess : PasscodeAction
 
     /**
-     * Signals a failed biometric authentication.
+     * Signals a failed external authentication.
      * @property message An optional error message.
      */
-    data class BiometricUnlockFailure(val message: String? = null) : PasscodeAction
+    data class ExternalUnlockFailure(val message: String? = null) : PasscodeAction
 
-    /** Signals that the user is not registered for biometrics. */
-    object BiometricUserNotRegistered : PasscodeAction
+    /** Signals that the user is not registered for external authentication. */
+    object ExternalAuthNotAvailable : PasscodeAction
 
-    /** Initiates the flow to disable biometric authentication (requires passcode verification). */
-    object DisableBiometrics : PasscodeAction
+    /** Initiates the flow to disable external authentication (requires passcode verification). */
+    object DisableExternalAuth : PasscodeAction
 
     /**
-     * Saves biometric registration data.
+     * Saves external authentication registration data.
      * @property registrationData The opaque data string to save.
      */
-    data class SaveBiometricRegistration(val registrationData: String) : PasscodeAction
+    data class SaveExternalRegistration(val registrationData: String) : PasscodeAction
 
-    /** Deletes stored biometric registration data. */
-    object DeleteBiometricRegistration : PasscodeAction
+    /** Deletes stored external authentication registration data. */
+    object DeleteExternalRegistration : PasscodeAction
 }
 
 /**
@@ -535,6 +536,6 @@ enum class PasscodeStep {
     /** User is verifying their old passcode before changing it. */
     ChangeVerify,
 
-    /** User is verifying their passcode to disable biometrics. */
-    DisableBiometrics,
+    /** User is verifying their passcode to disable external authentication. */
+    DisableExternalAuth,
 }

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
@@ -333,7 +333,14 @@ class PasscodeManager(
 
     private fun clearAllSecurityData() {
         adapter.deletePasscode()
-        updateState { it.copy(loadedPasscode = null, passcodeStep = PasscodeStep.Create) }
+        updateState {
+            it.copy(
+                loadedPasscode = null,
+                passcodeStep = PasscodeStep.Create,
+                isChangeFlow = false,
+                isExternalAuthEnabled = false,
+            )
+        }
         resetPasscodeEntryStates()
     }
 

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeStorageAdapter.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeStorageAdapter.kt
@@ -38,21 +38,42 @@ interface PasscodeStorageAdapter {
     fun deletePasscode()
 
     /**
-     * Saves biometric registration data (e.g. FIDO/WebAuthn credential) to persistent storage.
+yes     * Saves external authentication registration data (e.g. FIDO/WebAuthn credential) to persistent storage.
      *
      * @param registrationData The registration data string to be saved.
      */
+    @Deprecated(
+        message = "Use BiometricStorageAdapter from the biometrics library instead.",
+        replaceWith = ReplaceWith(
+            "BiometricStorageAdapter.saveRegistrationData(registrationData)",
+            "org.mifos.authenticator.biometrics.BiometricStorageAdapter",
+        ),
+    )
     fun saveRegistrationData(registrationData: String)
 
     /**
-     * Loads the stored biometric registration data from persistent storage.
+     * Loads the stored external authentication registration data from persistent storage.
      *
      * @return The loaded registration data, or `null` if none is stored.
      */
+    @Deprecated(
+        message = "Use BiometricStorageAdapter from the biometrics library instead.",
+        replaceWith = ReplaceWith(
+            "BiometricStorageAdapter.loadRegistrationData()",
+            "org.mifos.authenticator.biometrics.BiometricStorageAdapter",
+        ),
+    )
     fun loadRegistrationData(): String?
 
     /**
-     * Deletes the biometric registration data from persistent storage.
+     * Deletes the external authentication registration data from persistent storage.
      */
+    @Deprecated(
+        message = "Use BiometricStorageAdapter from the biometrics library instead.",
+        replaceWith = ReplaceWith(
+            "BiometricStorageAdapter.deleteRegistrationData()",
+            "org.mifos.authenticator.biometrics.BiometricStorageAdapter",
+        ),
+    )
     fun deleteRegistrationData()
 }

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/components/PasscodeHeader.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/components/PasscodeHeader.kt
@@ -63,7 +63,7 @@ fun PasscodeHeader(
         if (it == PasscodeStep.Confirm) zeroOffset else positiveOffset
     }
     val xTransitionHeader3 by transition.animateOffset(label = "Transition Offset Header 3") {
-        if (it == PasscodeStep.ChangeVerify || it == PasscodeStep.DisableBiometrics) zeroOffset else positiveOffset
+        if (it == PasscodeStep.ChangeVerify || it == PasscodeStep.DisableExternalAuth) zeroOffset else positiveOffset
     }
     val alphaHeader1 by transition.animateFloat(label = "Transition Alpha Header 1") {
         if (it == PasscodeStep.Create) 1.0F else 0.0F
@@ -72,7 +72,7 @@ fun PasscodeHeader(
         if (it == PasscodeStep.Confirm) 1.0F else 0.0F
     }
     val alphaHeader3 by transition.animateFloat(label = "Transition Alpha Header 3") {
-        if (it == PasscodeStep.ChangeVerify || it == PasscodeStep.DisableBiometrics) 1.0F else 0.0F
+        if (it == PasscodeStep.ChangeVerify || it == PasscodeStep.DisableExternalAuth) 1.0F else 0.0F
     }
     val scaleHeader1 by transition.animateFloat(label = "Transition Scale Header 1") {
         if (it == PasscodeStep.Create) 1.0F else 0.5F
@@ -81,7 +81,7 @@ fun PasscodeHeader(
         if (it == PasscodeStep.Confirm) 1.0F else 0.5F
     }
     val scaleHeader3 by transition.animateFloat(label = "Transition Scale Header 3") {
-        if (it == PasscodeStep.ChangeVerify || it == PasscodeStep.DisableBiometrics) 1.0F else 0.5F
+        if (it == PasscodeStep.ChangeVerify || it == PasscodeStep.DisableExternalAuth) 1.0F else 0.5F
     }
 
     Box(
@@ -119,7 +119,7 @@ fun PasscodeHeader(
                         style = textStyle,
                     )
                 }
-                PasscodeStep.ChangeVerify, PasscodeStep.DisableBiometrics -> {
+                PasscodeStep.ChangeVerify, PasscodeStep.DisableExternalAuth -> {
                     Text(
                         modifier = Modifier
                             .offset(x = xTransitionHeader3.x.dp)

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/components/PasscodeKeys.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/components/PasscodeKeys.kt
@@ -63,7 +63,7 @@ fun PasscodeKeys(
     keyElevation: CardElevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
     keyContainerColor: Color = Color.White,
     keySize: Dp = 60.dp,
-    biometricButton: @Composable ((Modifier) -> Unit)? = null,
+    externalAuthButton: @Composable ((Modifier) -> Unit)? = null,
 ) {
     val onEnterKeyClick = { keyTitle: String ->
         enterKey(keyTitle)
@@ -145,12 +145,12 @@ fun PasscodeKeys(
             )
         }
 
-        if (biometricButton != null) {
+        if (externalAuthButton != null) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.Center,
             ) {
-                biometricButton(Modifier.padding(2.dp))
+                externalAuthButton(Modifier.padding(2.dp))
             }
         }
     }

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/components/SystemAuthConfirmDialog.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/components/SystemAuthConfirmDialog.kt
@@ -34,8 +34,8 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import mifos_authenticator.mifos_authenticator_passcode.generated.resources.Res
-import mifos_authenticator.mifos_authenticator_passcode.generated.resources.enable_biometric_dialog_description
-import mifos_authenticator.mifos_authenticator_passcode.generated.resources.enable_biometric_dialog_title
+import mifos_authenticator.mifos_authenticator_passcode.generated.resources.enable_external_auth_dialog_description
+import mifos_authenticator.mifos_authenticator_passcode.generated.resources.enable_external_auth_dialog_title
 import mifos_authenticator.mifos_authenticator_passcode.generated.resources.no
 import mifos_authenticator.mifos_authenticator_passcode.generated.resources.yes
 import org.jetbrains.compose.resources.stringResource
@@ -70,7 +70,7 @@ fun SystemAuthSetupConfirmDialog(
                 Spacer(modifier = Modifier.height(20.dp))
 
                 Text(
-                    text = stringResource(resource = Res.string.enable_biometric_dialog_title),
+                    text = stringResource(resource = Res.string.enable_external_auth_dialog_title),
                     modifier = Modifier
                         .padding(8.dp),
                     style = titleTextStyle,
@@ -79,7 +79,7 @@ fun SystemAuthSetupConfirmDialog(
                 Spacer(modifier = Modifier.height(4.dp))
 
                 Text(
-                    text = stringResource(resource = Res.string.enable_biometric_dialog_description),
+                    text = stringResource(resource = Res.string.enable_external_auth_dialog_description),
                     modifier = Modifier
                         .padding(8.dp),
                     style = descriptionTextStyle,

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/screen/PasscodeScreen.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/screen/PasscodeScreen.kt
@@ -73,8 +73,8 @@ import org.mifos.authenticator.passcode.utility.ShakeAnimation.performShakeAnima
  * @param onPasscodeCreation Lambda to be invoked when a new passcode is successfully created.
  * @param onPasscodeChanged Lambda to be invoked when the passcode is successfully changed.
  * @param onPasscodeRejected Lambda to be invoked when an entered passcode (for unlock or change verification) is incorrect.
- * @param onDisableBiometrics Lambda to be invoked when biometrics are successfully disabled.
- * @param onBiometricError Lambda to be invoked when a biometric authentication error occurs.
+ * @param onDisableExternalAuth Lambda to be invoked when external authentication is successfully disabled.
+ * @param onExternalAuthError Lambda to be invoked when an external authentication error occurs.
  * @param modifier Optional [Modifier] for the screen's root layout.
  * @param appearanceConfig Configuration for the overall visual appearance of the screen.
  * @param logoConfig Configuration for the logo displayed on the screen.
@@ -83,7 +83,7 @@ import org.mifos.authenticator.passcode.utility.ShakeAnimation.performShakeAnima
  * @param buttonConfig Configuration for action buttons like "Skip" and "Forgot".
  * @param switchConfig Configuration for the passcode length switch.
  * @param dialogConfig Configuration for the "Passcode Mismatched" dialog.
- * @param biometricButton Optional composable to display a biometric authentication button.
+ * @param externalAuthButton Optional composable to display an external authentication button (e.g. biometrics).
  */
 @Composable
 fun PasscodeScreen(
@@ -93,8 +93,8 @@ fun PasscodeScreen(
     onPasscodeCreation: () -> Unit,
     onPasscodeChanged: () -> Unit = {},
     onPasscodeRejected: () -> Unit = {},
-    onDisableBiometrics: () -> Unit = {},
-    onBiometricError: (String?) -> Unit = {},
+    onDisableExternalAuth: () -> Unit = {},
+    onExternalAuthError: (String?) -> Unit = {},
     modifier: Modifier = Modifier,
     appearanceConfig: PasscodeAppearanceConfig = PasscodeAppearanceConfig(),
     logoConfig: PasscodeLogoConfig = PasscodeLogoConfig(),
@@ -103,7 +103,7 @@ fun PasscodeScreen(
     buttonConfig: PasscodeButtonConfig = PasscodeButtonConfig(),
     switchConfig: PasscodeSwitchConfig = PasscodeSwitchConfig(),
     dialogConfig: PasscodeDialogConfig = PasscodeDialogConfig(),
-    biometricButton: @Composable ((Modifier) -> Unit)? = null,
+    externalAuthButton: @Composable ((Modifier) -> Unit)? = null,
 ) {
     val effectiveLogoConfig = logoConfig.copy(
         logoPainter = logoConfig.logoPainter ?: painterResource(resource = Res.drawable.mifos_logo),
@@ -144,8 +144,8 @@ fun PasscodeScreen(
                 PasscodeEvent.OnPasscodeChanged -> {
                     onPasscodeChanged()
                 }
-                PasscodeEvent.OnDisableBiometricsSuccess -> {
-                    onDisableBiometrics()
+                PasscodeEvent.OnDisableExternalAuthSuccess -> {
+                    onDisableExternalAuth()
                 }
                 PasscodeEvent.OnRejectEnteredPasscode -> {
                     passcodeRejectedDialogVisible = true
@@ -159,12 +159,12 @@ fun PasscodeScreen(
                 PasscodeEvent.OnPasscodeDeletion -> {
                     onForgotButton()
                 }
-                is PasscodeEvent.OnBiometricUnlockFailure -> {
+                is PasscodeEvent.OnExternalUnlockFailure -> {
                     performShakeAnimation(xShake)
-                    onBiometricError(it.message)
+                    onExternalAuthError(it.message)
                 }
-                PasscodeEvent.OnBiometricUserNotRegistered -> {
-                    onBiometricError("Biometrics not enabled or invalid biometrics registered.")
+                PasscodeEvent.OnExternalAuthNotAvailable -> {
+                    onExternalAuthError("External authentication not enabled or not registered.")
                     performShakeAnimation(xShake)
                 }
             }
@@ -268,7 +268,7 @@ fun PasscodeScreen(
                 keyElevation = effectiveKeyConfig.keyElevation!!,
                 keyContainerColor = effectiveKeyConfig.keyContainerColor,
                 keySize = effectiveKeyConfig.keySize,
-                biometricButton = if (state.passcodeStep == PasscodeStep.Enter && state.isBiometricEnabled) biometricButton else null,
+                externalAuthButton = if (state.passcodeStep == PasscodeStep.Enter && state.isExternalAuthEnabled) externalAuthButton else null,
             )
             Spacer(modifier = Modifier.height(8.dp))
 

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/screen/PasscodeScreen.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/screen/PasscodeScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -44,9 +45,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_authenticator.mifos_authenticator_passcode.generated.resources.Res
 import mifos_authenticator.mifos_authenticator_passcode.generated.resources.mifos_logo
 import org.jetbrains.compose.resources.painterResource
-import org.mifos.authenticator.passcode.PasscodeAction
-import org.mifos.authenticator.passcode.PasscodeEvent
 import org.mifos.authenticator.passcode.PasscodeManager
+import org.mifos.authenticator.passcode.PasscodeResult
 import org.mifos.authenticator.passcode.PasscodeStep
 import org.mifos.authenticator.passcode.components.MifosIcon
 import org.mifos.authenticator.passcode.components.PasscodeForgotButton
@@ -63,18 +63,13 @@ import org.mifos.authenticator.passcode.utility.ShakeAnimation.performShakeAnima
 /**
  * A composable function that displays a comprehensive passcode entry screen.
  *
- * This screen handles various passcode flows, including creation, entry, and changing a passcode,
- * and integrates with the [PasscodeManager] to manage its state and logic. It offers extensive
- * customization options through several configuration objects.
+ * This screen handles various passcode flows including creation, entry, changing, and
+ * disabling external authentication. It integrates with [PasscodeManager] for state and logic,
+ * and delivers all outcomes via the [onResult] callback as [PasscodeResult] values.
  *
  * @param passcodeManager The [PasscodeManager] instance responsible for handling passcode logic.
- * @param onForgotButton Lambda to be invoked when the "Forgot Passcode" button is pressed.
- * @param onPasscodeConfirm Lambda to be invoked when an existing passcode is successfully entered.
- * @param onPasscodeCreation Lambda to be invoked when a new passcode is successfully created.
- * @param onPasscodeChanged Lambda to be invoked when the passcode is successfully changed.
- * @param onPasscodeRejected Lambda to be invoked when an entered passcode (for unlock or change verification) is incorrect.
- * @param onDisableExternalAuth Lambda to be invoked when external authentication is successfully disabled.
- * @param onExternalAuthError Lambda to be invoked when an external authentication error occurs.
+ * @param onResult Callback invoked with a [PasscodeResult] when a passcode operation completes.
+ *        Handle navigation and other outcomes here.
  * @param modifier Optional [Modifier] for the screen's root layout.
  * @param appearanceConfig Configuration for the overall visual appearance of the screen.
  * @param logoConfig Configuration for the logo displayed on the screen.
@@ -83,18 +78,14 @@ import org.mifos.authenticator.passcode.utility.ShakeAnimation.performShakeAnima
  * @param buttonConfig Configuration for action buttons like "Skip" and "Forgot".
  * @param switchConfig Configuration for the passcode length switch.
  * @param dialogConfig Configuration for the "Passcode Mismatched" dialog.
- * @param externalAuthButton Optional composable to display an external authentication button (e.g. biometrics).
+ * @param externalAuthButton Optional composable to display an external authentication button
+ *        (e.g. biometrics). Only shown when [PasscodeStep.Enter] is active and
+ *        [PasscodeState.isExternalAuthEnabled] is true.
  */
 @Composable
 fun PasscodeScreen(
     passcodeManager: PasscodeManager,
-    onForgotButton: () -> Unit,
-    onPasscodeConfirm: () -> Unit,
-    onPasscodeCreation: () -> Unit,
-    onPasscodeChanged: () -> Unit = {},
-    onPasscodeRejected: () -> Unit = {},
-    onDisableExternalAuth: () -> Unit = {},
-    onExternalAuthError: (String?) -> Unit = {},
+    onResult: (PasscodeResult) -> Unit,
     modifier: Modifier = Modifier,
     appearanceConfig: PasscodeAppearanceConfig = PasscodeAppearanceConfig(),
     logoConfig: PasscodeLogoConfig = PasscodeLogoConfig(),
@@ -132,42 +123,19 @@ fun PasscodeScreen(
         SnackbarHostState()
     }
 
-    LaunchedEffect(Unit) {
-        passcodeManager.events.collect {
-            when (it) {
-                PasscodeEvent.OnUnlockSuccess -> {
-                    onPasscodeConfirm()
-                }
-                PasscodeEvent.OnPasscodeCreateSuccess -> {
-                    onPasscodeCreation()
-                }
-                PasscodeEvent.OnPasscodeChanged -> {
-                    onPasscodeChanged()
-                }
-                PasscodeEvent.OnDisableExternalAuthSuccess -> {
-                    onDisableExternalAuth()
-                }
-                PasscodeEvent.OnRejectEnteredPasscode -> {
-                    passcodeRejectedDialogVisible = true
-                    performShakeAnimation(xShake)
-                    onPasscodeRejected()
-                }
-                PasscodeEvent.OnRejectConfirmationPasscode -> {
-                    passcodeRejectedDialogVisible = true
-                    performShakeAnimation(xShake)
-                }
-                PasscodeEvent.OnPasscodeDeletion -> {
-                    onForgotButton()
-                }
-                is PasscodeEvent.OnExternalUnlockFailure -> {
-                    performShakeAnimation(xShake)
-                    onExternalAuthError(it.message)
-                }
-                PasscodeEvent.OnExternalAuthNotAvailable -> {
-                    onExternalAuthError("External authentication not enabled or not registered.")
-                    performShakeAnimation(xShake)
-                }
-            }
+    var lastShakeTrigger by remember { mutableStateOf(state.shakeAnimationTrigger) }
+    LaunchedEffect(state.shakeAnimationTrigger) {
+        if (state.shakeAnimationTrigger != lastShakeTrigger) {
+            lastShakeTrigger = state.shakeAnimationTrigger
+            passcodeRejectedDialogVisible = true
+            performShakeAnimation(xShake)
+        }
+    }
+
+    DisposableEffect(passcodeManager) {
+        passcodeManager.setResultCallback(onResult)
+        onDispose {
+            passcodeManager.setResultCallback(null)
         }
     }
 
@@ -232,10 +200,10 @@ fun PasscodeScreen(
                         textStyle = effectiveSwitchConfig.switchTextStyle!!,
                         passcodeLength = state.passcodeLength,
                         onSelectFourDigit = {
-                            passcodeManager.trySendAction(PasscodeAction.UpdatePasscodeLength(PasscodeLength.FOUR_DIGIT))
+                            passcodeManager.updatePasscodeLength(PasscodeLength.FOUR_DIGIT)
                         },
                         onSelectSixDigit = {
-                            passcodeManager.trySendAction(PasscodeAction.UpdatePasscodeLength(PasscodeLength.SIX_DIGIT))
+                            passcodeManager.updatePasscodeLength(PasscodeLength.SIX_DIGIT)
                         },
                     )
                 }
@@ -244,17 +212,17 @@ fun PasscodeScreen(
             PasscodeKeys(
                 modifier = Modifier.padding(horizontal = 12.dp),
                 enterKey = {
-                    passcodeManager.trySendAction(PasscodeAction.EnterKey(it))
+                    passcodeManager.enterKey(it)
                 },
                 deleteKey = {
-                    passcodeManager.trySendAction(PasscodeAction.DeleteKey)
+                    passcodeManager.deleteKey()
                 },
                 deleteAllKeys = {
-                    passcodeManager.trySendAction(PasscodeAction.DeleteAllKeys)
+                    passcodeManager.deleteAllKeys()
                 },
                 passcodeVisible = state.passcodeVisible,
                 togglePasscodeVisibility = {
-                    passcodeManager.trySendAction(PasscodeAction.TogglePasscodeVisibility)
+                    passcodeManager.togglePasscodeVisibility()
                 },
                 shouldJumbleKeys =
                 if (state.passcodeStep == PasscodeStep.Enter) {
@@ -275,7 +243,7 @@ fun PasscodeScreen(
             AnimatedVisibility(state.passcodeStep == PasscodeStep.Enter) {
                 PasscodeForgotButton(
                     onForgotButton = {
-                        passcodeManager.trySendAction(PasscodeAction.ForgetPasscode)
+                        passcodeManager.forgetPasscode()
                     },
                     textStyle = effectiveButtonConfig.forgotButtonTextStyle!!,
                 )


### PR DESCRIPTION
### Summary

**Passcode Library — API Simplification:**
- Replaced action/event channel pattern with direct methods (`changePasscode()`, `logOut()`, `disableExternalAuth()`, `notifyExternalAuthSuccess()`, `setExternalAuthEnabled()`)
- Replaced 7 individual PasscodeScreen callbacks with single `onResult: (PasscodeResult) -> Unit`
- Replaced `PasscodeEvent` channel with `PasscodeResult` sealed interface (Verified, Created, Changed, ExternalAuthDisabled, Forgotten, Rejected)
- Made UI-internal actions (`enterKey`, `deleteKey`, etc.) `internal` — hidden from consumers
- Removed `CoroutineScope` dependency from `PasscodeManager` constructor
- Moved initialization logic into `init` block — no more `.initialize()` call to forget
- Fixed shake animation using counter-based trigger instead of boolean flag
- Fixed `clearAllSecurityData` not resetting `isChangeFlow`

**Library Decoupling:**
- Renamed all biometric-specific APIs to generic "external auth" names
- Removed registration data storage from `PasscodeManager` — consumers handle persistence via `BiometricStorageAdapter`
- Created `BiometricStorageAdapter` interface in the biometrics library
- Deprecated registration methods on `PasscodeStorageAdapter`

**Sample App Restructuring:**
- Split 378-line `SampleAppNavigation.kt` into focused files: `LoginScreen.kt`, `HomeScreen.kt`, `BiometricKey.kt`
- `SampleAppNavigation.kt` now contains only navigation graph (~130 lines)
- Removed unused `SettingsPasscodeScreen` route

**Documentation:**
- Updated both library READMEs to reflect new API
- Added "Using with Passcode Library" guide in biometrics README
- Added `BiometricStorageAdapter` implementation example

### Breaking Changes

- `PasscodeScreen`: 7 callbacks replaced by `onResult: (PasscodeResult) -> Unit`
- `PasscodeManager`: constructor no longer takes `CoroutineScope`, takes `isExternalAuthEnabled: Boolean` instead
- `PasscodeAction`, `PasscodeEvent` removed — use direct methods and `PasscodeResult`
- All `Biometric*` names renamed to `External*` / generic equivalents
