### PR TITLE
bug-fix: string builder reset on confirm set causing pass code screen to stuck on confirm step.

### DIFF
--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
@@ -276,7 +276,6 @@ class PasscodeManager(
             )
         }
         finalConfirmationPasscodeBuilder.clear()
-        creationPasscodeBuilder.clear()
     }
 
     private fun clearAllSecurityData() {
@@ -288,6 +287,7 @@ class PasscodeManager(
                 isChangeFlow = false,
             )
         }
+        creationPasscodeBuilder.clear()
         resetPasscodeEntryStates()
     }
 


### PR DESCRIPTION
Entering an invalid passcode on the confirm passcode screen was clearing the newly entered passcode, preventing further verification of the passcode, and thus getting to the confirm step unless the user logs out and then again starts passcode creation after login.

`handleConfirmPasscode` method in PasscodeManager was clearing the temporarily entered new passcode on the create passcode step. 