### PR TITLE
Add configurable passcode brute-force protection

### DIFF
--- a/cmp-sample-shared/build.gradle.kts
+++ b/cmp-sample-shared/build.gradle.kts
@@ -38,6 +38,10 @@ kotlin {
             implementation(libs.koin.android)
             implementation(libs.koin.androidx.compose)
         }
+
+        desktopTest.dependencies {
+            implementation(libs.kotlin.test)
+        }
     }
 
 }

--- a/cmp-sample-shared/src/commonMain/composeResources/values/strings.xml
+++ b/cmp-sample-shared/src/commonMain/composeResources/values/strings.xml
@@ -45,6 +45,9 @@
     <string name="biometric_error_invalid_arguments_registration">Registration failed due to invalid input. Try again.</string>
     <string name="biometric_error_unknown">Authentication failed. Try again.</string>
 
+    <!-- Passcode error messages -->
+    <string name="passcode_error_lockout">Too many failed passcode attempts. Try again later.</string>
+
     <!-- System authenticator button -->
     <string name="use_biometrics">Use Biometrics</string>
     <string name="setup_authentication_option">Set up Authentication Option</string>

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/PasscodeStorageAdapterImpl.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/PasscodeStorageAdapterImpl.kt
@@ -10,13 +10,33 @@
 package cmp.sample.shared
 
 import com.russhwolf.settings.Settings
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.mifos.authenticator.passcode.PasscodeAttemptState
+import org.mifos.authenticator.passcode.PasscodeAttemptStorageAdapter
 import org.mifos.authenticator.passcode.PasscodeStorageAdapter
 
 private const val PASSCODE_KEY = "org.mifos.authenticator.passcode"
+private const val ATTEMPT_STATE_KEY = "org.mifos.authenticator.passcode.attemptState"
+private const val ATTEMPT_STATE_VERSION = 1
+
+private val attemptStateJson = Json {
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+}
+
+@Serializable
+private data class StoredPasscodeAttemptState(
+    val version: Int = ATTEMPT_STATE_VERSION,
+    val failedAttempts: Int,
+    val lockoutCount: Int,
+    val lockedUntilEpochMillis: Long? = null,
+)
 
 class PasscodeStorageAdapterImpl(
     private val settings: Settings,
-) : PasscodeStorageAdapter {
+) : PasscodeStorageAdapter, PasscodeAttemptStorageAdapter {
     override fun savePasscode(passcode: String) {
         settings.putString(PASSCODE_KEY, passcode)
     }
@@ -27,5 +47,36 @@ class PasscodeStorageAdapterImpl(
 
     override fun deletePasscode() {
         settings.remove(PASSCODE_KEY)
+    }
+
+    override fun savePasscodeAttemptState(state: PasscodeAttemptState) {
+        val storedState = StoredPasscodeAttemptState(
+            failedAttempts = state.failedAttempts,
+            lockoutCount = state.lockoutCount,
+            lockedUntilEpochMillis = state.lockedUntilEpochMillis,
+        )
+        settings.putString(ATTEMPT_STATE_KEY, attemptStateJson.encodeToString(storedState))
+    }
+
+    override fun loadPasscodeAttemptState(): PasscodeAttemptState? {
+        val encodedState = settings.getStringOrNull(ATTEMPT_STATE_KEY) ?: return null
+        val storedState = runCatching {
+            attemptStateJson.decodeFromString<StoredPasscodeAttemptState>(encodedState)
+        }.getOrNull()
+
+        if (storedState?.version != ATTEMPT_STATE_VERSION) {
+            settings.remove(ATTEMPT_STATE_KEY)
+            return null
+        }
+
+        return PasscodeAttemptState(
+            failedAttempts = storedState.failedAttempts,
+            lockoutCount = storedState.lockoutCount,
+            lockedUntilEpochMillis = storedState.lockedUntilEpochMillis,
+        )
+    }
+
+    override fun deletePasscodeAttemptState() {
+        settings.remove(ATTEMPT_STATE_KEY)
     }
 }

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/navigation/SampleAppNavigation.kt
@@ -26,6 +26,9 @@ import cmp.sample.shared.ui.components.DialogBoxType
 import cmp.sample.shared.ui.components.MessageDialogBox
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.launch
+import mifos_authenticator.cmp_sample_shared.generated.resources.Res
+import mifos_authenticator.cmp_sample_shared.generated.resources.passcode_error_lockout
+import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.mifos.authenticator.biometrics.platformAuthenticationProvider
 import org.mifos.authenticator.passcode.PasscodeManager
@@ -40,6 +43,7 @@ fun SampleAppNavigation(
     val passcodeManager = koinInject<PasscodeManager>()
     val platformAuthenticationProvider = platformAuthenticationProvider.current
     val scope = rememberCoroutineScope()
+    val passcodeLockoutMessage = stringResource(Res.string.passcode_error_lockout)
 
     val isUsingPasscode = !passcodeStorageAdapter.loadPasscode().isNullOrBlank()
 
@@ -76,7 +80,12 @@ fun SampleAppNavigation(
                             scope.launch { platformAuthenticationProvider.unregister() }
                             navController.navigate(Route.LoginScreen) { popUpTo(0) }
                         }
-                        PasscodeResult.Rejected -> { }
+                        PasscodeResult.Rejected -> {
+                            if (passcodeManager.remainingLockoutMillis() != null) {
+                                dialogBoxType = DialogBoxType.ERROR
+                                dialogMessage = passcodeLockoutMessage
+                            }
+                        }
                     }
                 },
                 onBiometricSuccess = {
@@ -112,7 +121,12 @@ fun SampleAppNavigation(
                             scope.launch { platformAuthenticationProvider.unregister() }
                             navController.navigate(Route.LoginScreen) { popUpTo(0) }
                         }
-                        PasscodeResult.Rejected -> { }
+                        PasscodeResult.Rejected -> {
+                            if (passcodeManager.remainingLockoutMillis() != null) {
+                                dialogBoxType = DialogBoxType.ERROR
+                                dialogMessage = passcodeLockoutMessage
+                            }
+                        }
                         PasscodeResult.Created -> navController.popBackStack()
                         PasscodeResult.Changed -> navController.popBackStack()
                     }

--- a/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/PasscodeScreenWithBiometrics.kt
+++ b/cmp-sample-shared/src/commonMain/kotlin/cmp/sample/shared/platformAuthentication/PasscodeScreenWithBiometrics.kt
@@ -50,7 +50,7 @@ import org.mifos.authenticator.passcode.screen.PasscodeScreen
  *
  * Bridges the biometrics and passcode libraries, which never import each other.
  * Surfaces two independent callbacks:
- *  - [onPasscodeResult] for passcode-flow events (Verified, Created, Changed, Forgotten, Rejected)
+ *  - [onPasscodeResult] for passcode-flow events (Verified, Created, Changed, Forgotten, or Rejected)
  *  - [onBiometricSuccess] for a biometric authentication succeeding
  *
  * Biometric success is **not** translated into a [PasscodeResult] — it is delivered via

--- a/cmp-sample-shared/src/desktopTest/kotlin/cmp/sample/shared/PasscodeStorageAdapterImplTest.kt
+++ b/cmp-sample-shared/src/desktopTest/kotlin/cmp/sample/shared/PasscodeStorageAdapterImplTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
+ */
+package cmp.sample.shared
+
+import com.russhwolf.settings.PropertiesSettings
+import org.mifos.authenticator.passcode.PasscodeAttemptState
+import java.util.Properties
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+private const val ATTEMPT_STATE_KEY = "org.mifos.authenticator.passcode.attemptState"
+
+class PasscodeStorageAdapterImplTest {
+    @Test
+    fun roundTripsAttemptState() {
+        val storage = PasscodeStorageAdapterImpl(PropertiesSettings(Properties()))
+        val expected = PasscodeAttemptState(
+            failedAttempts = 2,
+            lockoutCount = 1,
+            lockedUntilEpochMillis = 12_345L,
+        )
+
+        storage.savePasscodeAttemptState(expected)
+
+        assertEquals(expected, storage.loadPasscodeAttemptState())
+    }
+
+    @Test
+    fun removesMalformedAttemptState() {
+        val settings = PropertiesSettings(Properties()).apply {
+            putString(ATTEMPT_STATE_KEY, "not-json")
+        }
+        val storage = PasscodeStorageAdapterImpl(settings)
+
+        assertNull(storage.loadPasscodeAttemptState())
+        assertFalse(settings.hasKey(ATTEMPT_STATE_KEY))
+    }
+
+    @Test
+    fun removesAttemptStateFromUnsupportedVersion() {
+        val settings = PropertiesSettings(Properties()).apply {
+            putString(
+                ATTEMPT_STATE_KEY,
+                """{"version":2,"failedAttempts":2,"lockoutCount":1,"lockedUntilEpochMillis":12345}""",
+            )
+        }
+        val storage = PasscodeStorageAdapterImpl(settings)
+
+        assertNull(storage.loadPasscodeAttemptState())
+        assertFalse(settings.hasKey(ATTEMPT_STATE_KEY))
+    }
+}

--- a/mifos-authenticator-passcode/README.md
+++ b/mifos-authenticator-passcode/README.md
@@ -12,14 +12,17 @@ Ensure you have the `io.github.openmf:mifos-authenticator-passcode` library adde
 
 ## Integration Steps
 
-### 1. Implement `PasscodeStorageAdapter`
+### 1. Implement the storage adapters
 
-Provide an implementation of `PasscodeStorageAdapter` to handle passcode persistence.
+Implement `PasscodeStorageAdapter` for the passcode and `PasscodeAttemptStorageAdapter` for
+failed-attempt state. Persist both in secure storage so an app restart cannot bypass a lockout.
 
 ```kotlin
+import org.mifos.authenticator.passcode.PasscodeAttemptState
+import org.mifos.authenticator.passcode.PasscodeAttemptStorageAdapter
 import org.mifos.authenticator.passcode.PasscodeStorageAdapter
 
-class MyPasscodeStorage : PasscodeStorageAdapter {
+class MyPasscodeStorage : PasscodeStorageAdapter, PasscodeAttemptStorageAdapter {
     override fun savePasscode(passcode: String) {
         // Save passcode to secure storage (e.g., EncryptedSharedPreferences, Keychain, or Settings)
     }
@@ -32,6 +35,19 @@ class MyPasscodeStorage : PasscodeStorageAdapter {
     override fun deletePasscode() {
         // Remove the passcode from storage
     }
+
+    override fun savePasscodeAttemptState(state: PasscodeAttemptState) {
+        // Serialize state to secure storage
+    }
+
+    override fun loadPasscodeAttemptState(): PasscodeAttemptState? {
+        // Deserialize the saved state or return null
+        return null
+    }
+
+    override fun deletePasscodeAttemptState() {
+        // Remove the saved attempt state
+    }
 }
 ```
 
@@ -43,6 +59,30 @@ class MyPasscodeStorage : PasscodeStorageAdapter {
 // DI module (e.g. Koin)
 single { PasscodeManager(adapter = get<PasscodeStorageAdapter>()) }
 ```
+
+Existing `PasscodeStorageAdapter`-only implementations remain compatible, but their attempt state
+is process-local. `isAttemptStatePersistent` is `true` only when the supplied passcode adapter also
+implements `PasscodeAttemptStorageAdapter`, or a separate attempt adapter is passed to the manager.
+Use persistent attempt storage when an app restart must not reset the limit.
+
+The default policy locks after five failed attempts for 30 seconds, then one minute, then five
+minutes for subsequent lockouts. Supply a `PasscodeBruteForcePolicy` to change those limits:
+
+```kotlin
+import kotlin.time.Duration.Companion.minutes
+
+PasscodeManager(
+    adapter = passcodeStorage,
+    bruteForcePolicy = PasscodeBruteForcePolicy(
+        maxFailedAttempts = 3,
+        lockoutDurations = listOf(1.minutes, 5.minutes, 15.minutes),
+    ),
+)
+```
+
+Lockout expiry uses the device wall clock so it can survive a normal restart. As with any client-only
+control, applications that must resist device-clock or local-storage tampering should enforce an
+additional attempt policy using a trusted backend.
 
 ```kotlin
 // Inject in any screen
@@ -80,7 +120,9 @@ composable<Route.PasscodeScreen> {
                 PasscodeResult.Created -> navController.navigate(Route.NextScreen) /* your post-creation destination */
                 PasscodeResult.Changed -> navController.navigate(Route.HomeScreen)
                 PasscodeResult.Forgotten -> navController.navigate(Route.LoginScreen)
-                PasscodeResult.Rejected -> { /* optional: vibrate device */ }
+                PasscodeResult.Rejected -> {
+                    passcodeManager.remainingLockoutMillis()?.let(::showRetryMessage)
+                }
             }
         },
         // Optional: show an external-auth bypass button during passcode entry
@@ -153,6 +195,7 @@ navController.navigate(Route.LoginScreen)
 ## Summary of Key Components
 
 *   **`PasscodeStorageAdapter`**: Interface for passcode persistence.
+*   **`PasscodeAttemptStorageAdapter`**: Interface for persistent failed-attempt and lockout state.
 *   **`PasscodeManager`**: State holder and logic for passcode operations.
 *   **`PasscodeScreen`**: The UI composable provided by the library.
 *   **`PasscodeResult`**: Sealed interface for all operation outcomes.
@@ -166,7 +209,8 @@ navController.navigate(Route.LoginScreen)
 - `Created`: New passcode created and confirmed.
 - `Changed`: Existing passcode changed.
 - `Forgotten`: Passcode deleted via "Forgot Passcode?" button.
-- `Rejected`: Incorrect passcode entered.
+- `Rejected`: Incorrect passcode entered, or passcode entry is currently locked. Call
+  `remainingLockoutMillis()` to distinguish an active lockout.
 
 ## Customization
 

--- a/mifos-authenticator-passcode/build.gradle.kts
+++ b/mifos-authenticator-passcode/build.gradle.kts
@@ -61,6 +61,10 @@ tasks.matching {
 
 kotlin {
     sourceSets {
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+        }
+
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)
         }

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeBruteForceProtection.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeBruteForceProtection.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
+ */
+package org.mifos.authenticator.passcode
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Configures how failed passcode verification attempts are throttled.
+ *
+ * Each group of [maxFailedAttempts] failures starts a lockout. Durations progress through
+ * [lockoutDurations], with the final duration reused for subsequent lockouts. A successful
+ * verification resets the progression.
+ */
+class PasscodeBruteForcePolicy(
+    val maxFailedAttempts: Int = 5,
+    lockoutDurations: List<Duration> = listOf(30.seconds, 1.minutes, 5.minutes),
+) {
+    val lockoutDurations: List<Duration> = lockoutDurations.toList()
+
+    init {
+        require(maxFailedAttempts > 0) { "maxFailedAttempts must be greater than zero" }
+        require(lockoutDurations.isNotEmpty()) { "lockoutDurations must not be empty" }
+        require(lockoutDurations.all { it.isFinite() && it > Duration.ZERO && it.inWholeMilliseconds > 0 }) {
+            "lockoutDurations must contain finite, positive durations of at least one millisecond"
+        }
+    }
+
+    internal fun durationFor(lockoutCount: Int): Duration =
+        lockoutDurations[lockoutCount.coerceIn(0, lockoutDurations.lastIndex)]
+}
+
+/**
+ * Persistence state used to preserve brute-force protection across app restarts.
+ *
+ * @property failedAttempts Failed verifications since the previous lockout.
+ * @property lockoutCount Lockouts since the last successful verification.
+ * @property lockedUntilEpochMillis End of the active lockout, as Unix epoch milliseconds.
+ */
+data class PasscodeAttemptState(
+    val failedAttempts: Int = 0,
+    val lockoutCount: Int = 0,
+    val lockedUntilEpochMillis: Long? = null,
+)
+
+/**
+ * Persists failed-attempt state. Implement this alongside [PasscodeStorageAdapter] to keep
+ * lockouts active after an app restart.
+ */
+interface PasscodeAttemptStorageAdapter {
+    fun savePasscodeAttemptState(state: PasscodeAttemptState)
+
+    fun loadPasscodeAttemptState(): PasscodeAttemptState?
+
+    fun deletePasscodeAttemptState()
+}
+
+internal class InMemoryPasscodeAttemptStorageAdapter : PasscodeAttemptStorageAdapter {
+    private var state: PasscodeAttemptState? = null
+
+    override fun savePasscodeAttemptState(state: PasscodeAttemptState) {
+        this.state = state
+    }
+
+    override fun loadPasscodeAttemptState(): PasscodeAttemptState? = state
+
+    override fun deletePasscodeAttemptState() {
+        state = null
+    }
+}

--- a/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
+++ b/mifos-authenticator-passcode/src/commonMain/kotlin/org/mifos/authenticator/passcode/PasscodeManager.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import org.mifos.authenticator.passcode.screen.PasscodeScreen
 import org.mifos.authenticator.passcode.utility.PasscodeLength
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 /**
  * Manages the state and logic for passcode creation, entry, and validation.
@@ -30,14 +32,75 @@ import org.mifos.authenticator.passcode.utility.PasscodeLength
  * since it is used across multiple screens.
  *
  * @param adapter The [PasscodeStorageAdapter] used for persisting and loading passcodes.
+ * @param attemptStorageAdapter Optional storage for preserving failed attempts and lockouts across
+ * app restarts. If omitted, an adapter that also implements [PasscodeAttemptStorageAdapter] is used.
+ * Otherwise, protection is process-local for backward compatibility; check
+ * [isAttemptStatePersistent] when persistent lockouts are required.
+ * @param bruteForcePolicy The failed-attempt limit and progressive lockout durations.
  */
 
-class PasscodeManager(
+class PasscodeManager private constructor(
     private val adapter: PasscodeStorageAdapter,
+    attemptStorageAdapter: PasscodeAttemptStorageAdapter?,
+    private val bruteForcePolicy: PasscodeBruteForcePolicy,
+    private val currentTimeMillis: () -> Long,
 ) {
+    constructor(adapter: PasscodeStorageAdapter) : this(
+        adapter = adapter,
+        attemptStorageAdapter = null,
+        bruteForcePolicy = PasscodeBruteForcePolicy(),
+        currentTimeMillis = ::systemCurrentTimeMillis,
+    )
+
+    constructor(
+        adapter: PasscodeStorageAdapter,
+        bruteForcePolicy: PasscodeBruteForcePolicy,
+    ) : this(
+        adapter = adapter,
+        attemptStorageAdapter = null,
+        bruteForcePolicy = bruteForcePolicy,
+        currentTimeMillis = ::systemCurrentTimeMillis,
+    )
+
+    constructor(
+        adapter: PasscodeStorageAdapter,
+        attemptStorageAdapter: PasscodeAttemptStorageAdapter,
+    ) : this(
+        adapter = adapter,
+        attemptStorageAdapter = attemptStorageAdapter,
+        bruteForcePolicy = PasscodeBruteForcePolicy(),
+        currentTimeMillis = ::systemCurrentTimeMillis,
+    )
+
+    constructor(
+        adapter: PasscodeStorageAdapter,
+        attemptStorageAdapter: PasscodeAttemptStorageAdapter,
+        bruteForcePolicy: PasscodeBruteForcePolicy,
+    ) : this(
+        adapter = adapter,
+        attemptStorageAdapter = attemptStorageAdapter,
+        bruteForcePolicy = bruteForcePolicy,
+        currentTimeMillis = ::systemCurrentTimeMillis,
+    )
+
+    private val persistentAttemptStorageAdapter = attemptStorageAdapter
+        ?: (adapter as? PasscodeAttemptStorageAdapter)
+
+    /** Whether failed attempts and lockouts survive recreation of this manager. */
+    val isAttemptStatePersistent: Boolean = persistentAttemptStorageAdapter != null
+
+    private val attemptStorageAdapter = persistentAttemptStorageAdapter
+        ?: InMemoryPasscodeAttemptStorageAdapter()
+
+    private val initialPasscode = adapter.loadPasscode()
+    private var attemptState = normalizeAttemptState(
+        attemptStorageAdapter = this.attemptStorageAdapter,
+        passcodeExists = initialPasscode != null,
+    )
+
     private val _state = MutableStateFlow(
         PasscodeState(
-            loadedPasscode = adapter.loadPasscode(),
+            loadedPasscode = initialPasscode,
         ),
     )
 
@@ -52,18 +115,15 @@ class PasscodeManager(
     private val finalConfirmationPasscodeBuilder = StringBuilder()
 
     init {
-        val loaded = adapter.loadPasscode()
-
         when {
-            loaded != null -> {
+            initialPasscode != null -> {
                 updateState {
                     it.copy(
-                        loadedPasscode = loaded,
                         passcodeStep = PasscodeStep.Enter,
                     )
                 }
                 updatePasscodeLength(
-                    if (loaded.length == 6) {
+                    if (initialPasscode.length == 6) {
                         PasscodeLength.SIX_DIGIT
                     } else {
                         PasscodeLength.FOUR_DIGIT
@@ -141,6 +201,11 @@ class PasscodeManager(
     }
 
     internal fun enterKey(key: String) {
+        if (remainingLockoutMillis() != null) {
+            emitResult(PasscodeResult.Rejected)
+            return
+        }
+
         val currentState = _state.value
         if (currentState.filledDots >= _state.value.passcodeLength.length) return
 
@@ -190,6 +255,7 @@ class PasscodeManager(
     private fun handleChangeVerifyPasscode() {
         val loadedPasscode = adapter.loadPasscode()
         if (finalConfirmationPasscodeBuilder.toString() == loadedPasscode) {
+            clearAttemptState()
             updateState {
                 it.copy(
                     passcodeStep = PasscodeStep.Create,
@@ -204,7 +270,7 @@ class PasscodeManager(
             updateState {
                 it.copy(shakeAnimationTrigger = it.shakeAnimationTrigger + 1)
             }
-            emitResult(PasscodeResult.Rejected)
+            recordFailedAttempt()
         }
         resetPasscodeEntryStates()
     }
@@ -224,6 +290,7 @@ class PasscodeManager(
         val newPasscode = finalConfirmationPasscodeBuilder.toString()
         if (creationPasscodeBuilder.toString() == newPasscode) {
             adapter.savePasscode(newPasscode)
+            clearAttemptState()
             val isChange = _state.value.isChangeFlow
             updateState {
                 it.copy(
@@ -253,15 +320,101 @@ class PasscodeManager(
 
     private fun handleEnterPasscode() {
         if (finalConfirmationPasscodeBuilder.toString() == _state.value.loadedPasscode) {
+            clearAttemptState()
             emitResult(PasscodeResult.Verified)
         } else {
-            emitResult(PasscodeResult.Rejected)
             updateState {
                 it.copy(shakeAnimationTrigger = it.shakeAnimationTrigger + 1)
             }
+            recordFailedAttempt()
         }
         resetPasscodeEntryStates()
     }
+
+    private fun recordFailedAttempt() {
+        val failedAttempts = attemptState.failedAttempts + 1
+        if (failedAttempts < bruteForcePolicy.maxFailedAttempts) {
+            updateAttemptState(attemptState.copy(failedAttempts = failedAttempts))
+            emitResult(PasscodeResult.Rejected)
+            return
+        }
+
+        val now = now()
+        val lockoutMillis = bruteForcePolicy.durationFor(attemptState.lockoutCount).inWholeMilliseconds
+        val lockedUntil = if (now > Long.MAX_VALUE - lockoutMillis) {
+            Long.MAX_VALUE
+        } else {
+            now + lockoutMillis
+        }
+        val nextLockoutCount = if (attemptState.lockoutCount == Int.MAX_VALUE) {
+            Int.MAX_VALUE
+        } else {
+            attemptState.lockoutCount + 1
+        }
+        updateAttemptState(
+            PasscodeAttemptState(
+                lockoutCount = nextLockoutCount,
+                lockedUntilEpochMillis = lockedUntil,
+            ),
+        )
+        emitResult(PasscodeResult.Rejected)
+    }
+
+    /** Returns the active lockout's remaining duration, or `null` when passcode entry is allowed. */
+    fun remainingLockoutMillis(): Long? {
+        val lockedUntil = attemptState.lockedUntilEpochMillis ?: return null
+        val now = now()
+        if (lockedUntil > now) return lockedUntil - now
+
+        updateAttemptState(attemptState.copy(lockedUntilEpochMillis = null))
+        return null
+    }
+
+    private fun normalizeAttemptState(
+        attemptStorageAdapter: PasscodeAttemptStorageAdapter,
+        passcodeExists: Boolean,
+    ): PasscodeAttemptState {
+        if (!passcodeExists) {
+            attemptStorageAdapter.deletePasscodeAttemptState()
+            return PasscodeAttemptState()
+        }
+
+        val stored = attemptStorageAdapter.loadPasscodeAttemptState() ?: return PasscodeAttemptState()
+        val lockedUntil = stored.lockedUntilEpochMillis?.takeIf { it > now() }
+        val normalized = stored.copy(
+            failedAttempts = if (lockedUntil != null) {
+                0
+            } else {
+                stored.failedAttempts.coerceIn(0, bruteForcePolicy.maxFailedAttempts - 1)
+            },
+            lockoutCount = stored.lockoutCount.coerceAtLeast(0),
+            lockedUntilEpochMillis = lockedUntil,
+        )
+        if (normalized != stored) {
+            updateStoredAttemptState(normalized)
+        }
+        return normalized
+    }
+
+    private fun updateAttemptState(state: PasscodeAttemptState) {
+        attemptState = state
+        updateStoredAttemptState(state)
+    }
+
+    private fun updateStoredAttemptState(state: PasscodeAttemptState) {
+        if (state == PasscodeAttemptState()) {
+            attemptStorageAdapter.deletePasscodeAttemptState()
+        } else {
+            attemptStorageAdapter.savePasscodeAttemptState(state)
+        }
+    }
+
+    private fun clearAttemptState() {
+        attemptState = PasscodeAttemptState()
+        attemptStorageAdapter.deletePasscodeAttemptState()
+    }
+
+    private fun now(): Long = currentTimeMillis().coerceAtLeast(0)
 
     private fun resetPasscodeEntryStates() {
         updateState {
@@ -280,6 +433,7 @@ class PasscodeManager(
 
     private fun clearAllSecurityData() {
         adapter.deletePasscode()
+        clearAttemptState()
         updateState {
             it.copy(
                 loadedPasscode = null,
@@ -293,6 +447,20 @@ class PasscodeManager(
 
     private fun updateState(update: (PasscodeState) -> PasscodeState) {
         _state.update { update(it) }
+    }
+
+    internal companion object {
+        fun createForTest(
+            adapter: PasscodeStorageAdapter,
+            attemptStorageAdapter: PasscodeAttemptStorageAdapter,
+            bruteForcePolicy: PasscodeBruteForcePolicy,
+            currentTimeMillis: () -> Long,
+        ): PasscodeManager = PasscodeManager(
+            adapter = adapter,
+            attemptStorageAdapter = attemptStorageAdapter,
+            bruteForcePolicy = bruteForcePolicy,
+            currentTimeMillis = currentTimeMillis,
+        )
     }
 }
 
@@ -339,7 +507,7 @@ sealed interface PasscodeResult {
     /** Passcode deleted via "Forgot Passcode?" button. */
     data object Forgotten : PasscodeResult
 
-    /** Incorrect passcode entered. */
+    /** Incorrect passcode entered, or passcode entry is currently locked. */
     data object Rejected : PasscodeResult
 }
 
@@ -362,3 +530,6 @@ enum class PasscodeStep {
     /** User is verifying their old passcode before changing it. */
     ChangeVerify,
 }
+
+@OptIn(ExperimentalTime::class)
+private fun systemCurrentTimeMillis(): Long = Clock.System.now().toEpochMilliseconds()

--- a/mifos-authenticator-passcode/src/commonTest/kotlin/org/mifos/authenticator/passcode/PasscodeManagerBruteForceTest.kt
+++ b/mifos-authenticator-passcode/src/commonTest/kotlin/org/mifos/authenticator/passcode/PasscodeManagerBruteForceTest.kt
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mifos-passcode-cmp/blob/development/LICENSE
+ */
+package org.mifos.authenticator.passcode
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class PasscodeManagerBruteForceTest {
+    @Test
+    fun passcodeStorageAlsoPersistsAttemptsWhenItImplementsBothAdapters() {
+        val storage = TestStorage(passcode = PASSCODE)
+        val manager = PasscodeManager(
+            adapter = storage,
+            bruteForcePolicy = PasscodeBruteForcePolicy(
+                maxFailedAttempts = 3,
+                lockoutDurations = listOf(1.seconds),
+            ),
+        )
+
+        enterPasscode(manager, WRONG_PASSCODE)
+
+        assertTrue(manager.isAttemptStatePersistent)
+        assertEquals(1, storage.attemptState?.failedAttempts)
+    }
+
+    @Test
+    fun legacyStorageUsesProcessLocalAttemptState() {
+        val manager = PasscodeManager(LegacyStorage(passcode = PASSCODE))
+
+        assertFalse(manager.isAttemptStatePersistent)
+    }
+
+    @Test
+    fun lockoutPersistsAcrossManagerRecreationAndClearsAfterVerification() {
+        val storage = TestStorage(passcode = PASSCODE)
+        var now = 1_000L
+        val policy = PasscodeBruteForcePolicy(
+            maxFailedAttempts = 3,
+            lockoutDurations = listOf(1.seconds, 5.seconds),
+        )
+        val results = mutableListOf<PasscodeResult>()
+        val manager = createManager(storage, policy) { now }
+        manager.setResultCallback(results::add)
+
+        enterPasscode(manager, WRONG_PASSCODE)
+        enterPasscode(manager, WRONG_PASSCODE)
+        enterPasscode(manager, WRONG_PASSCODE)
+
+        assertEquals(3, results.count { it == PasscodeResult.Rejected })
+        assertEquals(1_000L, manager.remainingLockoutMillis())
+        assertEquals(2_000L, storage.attemptState?.lockedUntilEpochMillis)
+
+        val restartedResults = mutableListOf<PasscodeResult>()
+        val restartedManager = createManager(storage, policy) { now }
+        restartedManager.setResultCallback(restartedResults::add)
+        restartedManager.enterKey("1")
+
+        assertEquals(PasscodeResult.Rejected, restartedResults.single())
+        assertEquals(1_000L, restartedManager.remainingLockoutMillis())
+        assertEquals(0, restartedManager.state.value.filledDots)
+
+        now = 2_000L
+        enterPasscode(restartedManager, PASSCODE)
+
+        assertEquals(PasscodeResult.Verified, restartedResults.last())
+        assertNull(storage.attemptState)
+    }
+
+    @Test
+    fun repeatedLockoutsUseProgressiveDurations() {
+        val storage = TestStorage(passcode = PASSCODE)
+        var now = 10_000L
+        val policy = PasscodeBruteForcePolicy(
+            maxFailedAttempts = 2,
+            lockoutDurations = listOf(1.seconds, 5.seconds),
+        )
+        val results = mutableListOf<PasscodeResult>()
+        val manager = createManager(storage, policy) { now }
+        manager.setResultCallback(results::add)
+
+        enterPasscode(manager, WRONG_PASSCODE)
+        enterPasscode(manager, WRONG_PASSCODE)
+        assertEquals(PasscodeResult.Rejected, results.last())
+        assertEquals(1_000L, manager.remainingLockoutMillis())
+
+        now += 1_000L
+        enterPasscode(manager, WRONG_PASSCODE)
+        enterPasscode(manager, WRONG_PASSCODE)
+        assertEquals(PasscodeResult.Rejected, results.last())
+        assertEquals(5_000L, manager.remainingLockoutMillis())
+
+        now += 5_000L
+        enterPasscode(manager, WRONG_PASSCODE)
+        enterPasscode(manager, WRONG_PASSCODE)
+        assertEquals(PasscodeResult.Rejected, results.last())
+        assertEquals(5_000L, manager.remainingLockoutMillis())
+        assertEquals(3, storage.attemptState?.lockoutCount)
+    }
+
+    @Test
+    fun expiredLockoutStillEscalatesAfterManagerRecreation() {
+        val storage = TestStorage(passcode = PASSCODE).apply {
+            attemptState = PasscodeAttemptState(
+                lockoutCount = 1,
+                lockedUntilEpochMillis = 2_000L,
+            )
+        }
+        val policy = PasscodeBruteForcePolicy(
+            maxFailedAttempts = 2,
+            lockoutDurations = listOf(1.seconds, 5.seconds),
+        )
+        val results = mutableListOf<PasscodeResult>()
+        val manager = createManager(storage, policy) { 2_000L }
+        manager.setResultCallback(results::add)
+
+        enterPasscode(manager, WRONG_PASSCODE)
+        enterPasscode(manager, WRONG_PASSCODE)
+
+        assertEquals(PasscodeResult.Rejected, results.last())
+        assertEquals(5_000L, manager.remainingLockoutMillis())
+        assertEquals(2, storage.attemptState?.lockoutCount)
+        assertEquals(7_000L, storage.attemptState?.lockedUntilEpochMillis)
+    }
+
+    @Test
+    fun policyRejectsInfiniteLockoutDurations() {
+        assertFailsWith<IllegalArgumentException> {
+            PasscodeBruteForcePolicy(lockoutDurations = listOf(Duration.INFINITE))
+        }
+    }
+
+    @Test
+    fun activeLockoutDiscardsPartiallyPersistedFailedAttempts() {
+        val storage = TestStorage(passcode = PASSCODE).apply {
+            attemptState = PasscodeAttemptState(
+                failedAttempts = Int.MAX_VALUE,
+                lockoutCount = -1,
+                lockedUntilEpochMillis = 2_000L,
+            )
+        }
+        val results = mutableListOf<PasscodeResult>()
+        val manager = createManager(
+            storage = storage,
+            policy = PasscodeBruteForcePolicy(maxFailedAttempts = 3, lockoutDurations = listOf(1.seconds)),
+            currentTimeMillis = { 1_000L },
+        )
+        manager.setResultCallback(results::add)
+
+        manager.enterKey("1")
+
+        assertEquals(PasscodeAttemptState(lockedUntilEpochMillis = 2_000L), storage.attemptState)
+        assertEquals(PasscodeResult.Rejected, results.single())
+        assertEquals(1_000L, manager.remainingLockoutMillis())
+        assertEquals(0, manager.state.value.filledDots)
+    }
+
+    @Test
+    fun changePasscodeVerificationIsRateLimited() {
+        val storage = TestStorage(passcode = PASSCODE)
+        val results = mutableListOf<PasscodeResult>()
+        val manager = createManager(
+            storage = storage,
+            policy = PasscodeBruteForcePolicy(maxFailedAttempts = 2, lockoutDurations = listOf(1.seconds)),
+            currentTimeMillis = { 1_000L },
+        )
+        manager.setResultCallback(results::add)
+
+        manager.changePasscode()
+        enterPasscode(manager, WRONG_PASSCODE)
+        enterPasscode(manager, WRONG_PASSCODE)
+
+        assertEquals(PasscodeResult.Rejected, results.last())
+        assertEquals(1_000L, manager.remainingLockoutMillis())
+        assertEquals(PasscodeStep.ChangeVerify, manager.state.value.passcodeStep)
+    }
+
+    @Test
+    fun logoutClearsPersistedAttemptState() {
+        val storage = TestStorage(passcode = PASSCODE)
+        val manager = createManager(
+            storage = storage,
+            policy = PasscodeBruteForcePolicy(maxFailedAttempts = 3, lockoutDurations = listOf(1.seconds)),
+            currentTimeMillis = { 1_000L },
+        )
+
+        enterPasscode(manager, WRONG_PASSCODE)
+        assertEquals(1, storage.attemptState?.failedAttempts)
+
+        manager.logOut()
+
+        assertNull(storage.passcode)
+        assertNull(storage.attemptState)
+    }
+
+    private fun createManager(
+        storage: TestStorage,
+        policy: PasscodeBruteForcePolicy,
+        currentTimeMillis: () -> Long,
+    ): PasscodeManager = PasscodeManager.createForTest(
+        adapter = storage,
+        attemptStorageAdapter = storage,
+        bruteForcePolicy = policy,
+        currentTimeMillis = currentTimeMillis,
+    )
+
+    private fun enterPasscode(manager: PasscodeManager, passcode: String) {
+        passcode.forEach { manager.enterKey(it.toString()) }
+    }
+
+    private class TestStorage(
+        var passcode: String?,
+    ) : PasscodeStorageAdapter, PasscodeAttemptStorageAdapter {
+        var attemptState: PasscodeAttemptState? = null
+
+        override fun savePasscode(passcode: String) {
+            this.passcode = passcode
+        }
+
+        override fun loadPasscode(): String? = passcode
+
+        override fun deletePasscode() {
+            passcode = null
+        }
+
+        override fun savePasscodeAttemptState(state: PasscodeAttemptState) {
+            attemptState = state
+        }
+
+        override fun loadPasscodeAttemptState(): PasscodeAttemptState? = attemptState
+
+        override fun deletePasscodeAttemptState() {
+            attemptState = null
+        }
+    }
+
+    private class LegacyStorage(
+        var passcode: String?,
+    ) : PasscodeStorageAdapter {
+        override fun savePasscode(passcode: String) {
+            this.passcode = passcode
+        }
+
+        override fun loadPasscode(): String? = passcode
+
+        override fun deletePasscode() {
+            passcode = null
+        }
+    }
+
+    private companion object {
+        const val PASSCODE = "1234"
+        const val WRONG_PASSCODE = "9999"
+    }
+}


### PR DESCRIPTION
## Summary

Adds configurable attempt limits and progressive lockouts to `PasscodeManager`. Lockout state can be persisted through a separate storage adapter, while the existing `PasscodeManager(adapter)` API remains compatible.

- Uses five attempts with 30-second, one-minute, and five-minute lockouts by default.
- Applies the same limit when verifying the current passcode during a passcode change.
- Updates the sample and integration guide to persist attempt state and handle an active lockout.

Fixes #71

## Screenshots

No layout changes. The sample reuses its existing error dialog to show the lockout message.

## Verification

- `./gradlew check` (blocked locally because the required `ios_simulator_arm64` SDK is not installed)
- `./gradlew --rerun-tasks :mifos-authenticator-passcode:desktopTest :cmp-sample-shared:desktopTest`
- `./gradlew --rerun-tasks :cmp-sample-shared:compileDebugKotlinAndroid :mifos-authenticator-passcode:compileDebugKotlinAndroid`

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the static analysis check `./gradlew check` to make sure you didn't break anything
- [x] If you have multiple commits please combine them into one commit by squashing them.
